### PR TITLE
Takes care of #62

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -18,7 +18,8 @@ from tagging.models import Tag
 from dojo import settings
 from dojo.models import Finding, Product_Type, Product, ScanSettings, VA, \
     Check_List, User, Engagement, Test, Test_Type, Notes, Risk_Acceptance, \
-    Development_Environment, Dojo_User, Scan, Endpoint, Stub_Finding, Finding_Template, Report, FindingImage
+    Development_Environment, Dojo_User, Scan, Endpoint, Stub_Finding, Finding_Template, Report, FindingImage, \
+    UserContactInfo
 
 RE_DATE = re.compile(r'(\d{4})-(\d\d?)-(\d\d?)$')
 localtz = timezone(settings.TIME_ZONE)
@@ -163,12 +164,7 @@ class ProductForm(forms.ModelForm):
     prod_type = forms.ModelChoiceField(label='Product Type',
                                        queryset=Product_Type.objects.all(),
                                        required=True)
-    prod_manager = forms.CharField(max_length=30, label="Product Manager",
-                                   required=False)
-    tech_contact = forms.CharField(max_length=30, label="Technical Contact",
-                                   required=False)
-    manager = forms.CharField(max_length=30, label="Team Manager",
-                              required=False)
+
     authorized_users = forms.ModelMultipleChoiceField(
         queryset=None,
         required=False, label="Authorized Users")
@@ -185,7 +181,7 @@ class ProductForm(forms.ModelForm):
 
     class Meta:
         model = Product
-        fields = ['name', 'description', 'tags', 'prod_manager', 'tech_contact', 'manager', 'prod_type',
+        fields = ['name', 'description', 'tags', 'product_manager', 'technical_contact', 'team_manager', 'prod_type',
                   'authorized_users']
 
 
@@ -212,12 +208,7 @@ class Product_TypeProductForm(forms.ModelForm):
     name = forms.CharField(max_length=50, required=True)
     description = forms.CharField(widget=forms.Textarea(attrs={}),
                                   required=True)
-    prod_manager = forms.CharField(max_length=30, label="Product Manager",
-                                   required=False)
-    tech_contact = forms.CharField(max_length=30, label="Technical Contact",
-                                   required=False)
-    manager = forms.CharField(max_length=30, label="Team Manager",
-                              required=False)
+
     authorized_users = forms.ModelMultipleChoiceField(
         queryset=None,
         required=False, label="Authorized Users")
@@ -229,7 +220,7 @@ class Product_TypeProductForm(forms.ModelForm):
 
     class Meta:
         model = Product
-        fields = ['name', 'description', 'prod_manager', 'tech_contact', 'manager', 'prod_type', 'authorized_users']
+        fields = ['name', 'description', 'product_manager', 'technical_contact', 'team_manager', 'prod_type', 'authorized_users']
 
 
 class ImportScanForm(forms.Form):
@@ -1074,6 +1065,12 @@ class DeleteUserForm(forms.ModelForm):
         exclude = ['username', 'first_name', 'last_name', 'email', 'is_active',
                    'is_staff', 'is_superuser', 'password', 'last_login', 'groups',
                    'date_joined', 'user_permissions']
+
+
+class UserContactInfoForm(forms.ModelForm):
+    class Meta:
+        model = UserContactInfo
+        exclude = ['user']
 
 
 def get_years():

--- a/dojo/management/commands/migrate_product_contacts.py
+++ b/dojo/management/commands/migrate_product_contacts.py
@@ -1,0 +1,89 @@
+from django.core.management.base import BaseCommand
+
+from pytz import timezone
+import dojo.settings as settings
+from dojo.models import Product, Dojo_User
+
+locale = timezone(settings.TIME_ZONE)
+
+"""
+Authors: Jay Paz
+        The following three fields are deprecated and no longer in use.
+        They remain in model for backwards compatibility and will be removed
+        in a future release.  prod_manager, tech_contact, manager
+
+        The admin script migrate_product_contacts should be used to migrate data from
+        these fields to their replacements.  ./manage.py migrate_product_contacts
+"""
+
+
+class Command(BaseCommand):
+    help = 'The Product fields prod_manager, tech_contact, manager have been marked for deprecation.  ' \
+           'Run this script to migrate to new contact fields.'
+
+    def handle(self, *args, **options):
+        products = Product.objects.all()
+
+        count = 0
+        contact_count = 0
+        user_created = 0
+
+        for prod in products:
+            product_updated = False
+            if prod.prod_manager != '0':
+                fname = prod.prod_manager.split()[0]
+                lname = prod.prod_manager.split()[1]
+                user, created = Dojo_User.objects.get_or_create(first_name=fname, last_name=lname)
+                if created:
+                    user.username = fname + '.' + lname
+                    user.set_unusable_password()
+                    user.is_staff = False
+                    user.is_superuser = False
+                    user.active = True
+                    user.save()
+                    user_created += 1
+                prod.product_manager = user
+                prod.prod_manager = '0'
+                prod.save()
+                contact_count += 1
+                product_updated = True
+            if prod.manager != '0':
+                fname = prod.manager.split()[0]
+                lname = prod.manager.split()[1]
+                user, created = Dojo_User.objects.get_or_create(first_name=fname, last_name=lname)
+                if created:
+                    user.username = fname + '.' + lname
+                    user.set_unusable_password()
+                    user.is_staff = False
+                    user.is_superuser = False
+                    user.active = True
+                    user.save()
+                    user_created += 1
+                prod.team_manager = user
+                prod.manager = '0'
+                prod.save()
+                contact_count += 1
+                product_updated = True
+            if prod.tech_contact != '0':
+                fname = prod.tech_contact.split()[0]
+                lname = prod.tech_contact.split()[1]
+                user, created = Dojo_User.objects.get_or_create(first_name=fname, last_name=lname)
+                if created:
+                    user.username = fname + '.' + lname
+                    user.set_unusable_password()
+                    user.is_staff = False
+                    user.is_superuser = False
+                    user.active = True
+                    user.save()
+                    user_created += 1
+                prod.technical_contact = user
+                prod.tech_contact = '0'
+                prod.save()
+                contact_count += 1
+                product_updated = True
+
+            if product_updated:
+                count += 1
+
+        print 'A total of %d products have been migrated.  A total of %d contacts were updated.  ' \
+              'A total of %d users were created' % (count, contact_count, user_created)

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -11,6 +11,7 @@ from django.contrib import admin
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
+from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models import Q
 from django.utils.timezone import now
@@ -46,6 +47,22 @@ class Dojo_User(User):
 
     def __unicode__(self):
         return self.get_full_name()
+
+
+class UserContactInfo(models.Model):
+    user = models.OneToOneField(User)
+    title = models.CharField(blank=True, null=True, max_length=150)
+    phone_regex = RegexValidator(regex=r'^\+?1?\d{9,15}$',
+                                 message="Phone number must be entered in the format: '+999999999'. "
+                                         "Up to 15 digits allowed.")
+    phone_number = models.CharField(validators=[phone_regex], blank=True, max_length=15,
+                                    help_text="Phone number must be entered in the format: '+999999999'. "
+                                              "Up to 15 digits allowed.")
+    cell_number = models.CharField(validators=[phone_regex], blank=True, max_length=15,
+                                   help_text="Phone number must be entered in the format: '+999999999'. "
+                                             "Up to 15 digits allowed.")
+    twitter_username = models.CharField(blank=True, null=True, max_length=150)
+    github_username = models.CharField(blank=True, null=True, max_length=150)
 
 
 class Contact(models.Model):
@@ -110,9 +127,22 @@ class Test_Type(models.Model):
 class Product(models.Model):
     name = models.CharField(max_length=300)
     description = models.CharField(max_length=2000)
-    prod_manager = models.CharField(default=0, max_length=200)
-    tech_contact = models.CharField(default=0, max_length=200)
-    manager = models.CharField(default=0, max_length=200)
+    '''
+        The following three fields are deprecated and no longer in use.
+        They remain in model for backwards compatibility and will be removed
+        in a future release.  prod_manager, tech_contact, manager
+
+        The admin script migrate_product_contacts should be used to migrate data from
+        these fields to their replacements.  ./manage.py migrate_product_contacts
+    '''
+    prod_manager = models.CharField(default=0, max_length=200)  # unused
+    tech_contact = models.CharField(default=0, max_length=200)  # unused
+    manager = models.CharField(default=0, max_length=200)  # unused
+
+    product_manager = models.ForeignKey(Dojo_User, null=True, blank=True, related_name='product_manager')
+    technical_contact = models.ForeignKey(Dojo_User, null=True, blank=True, related_name='technical_contact')
+    team_manager = models.ForeignKey(Dojo_User, null=True, blank=True, related_name='team_manager')
+
     created = models.DateTimeField(editable=False, null=True, blank=True)
     prod_type = models.ForeignKey(Product_Type, related_name='prod_type',
                                   null=True, blank=True)
@@ -581,10 +611,12 @@ class Finding(models.Model):
 
     def save(self, *args, **kwargs):
         super(Finding, self).save(*args, **kwargs)
-        if hasattr(settings,'ENABLE_DEDUPLICATION'):
+        if hasattr(settings, 'ENABLE_DEDUPLICATION'):
             if settings.ENABLE_DEDUPLICATION:
-                eng_findings_cwe = Finding.objects.filter(test__engagement__product=self.test.engagement.product, cwe=self.cwe).exclude(id=self.id).exclude(cwe=None)
-                eng_findings_title = Finding.objects.filter(test__engagement__product=self.test.engagement.product, title=self.title).exclude(id=self.id)
+                eng_findings_cwe = Finding.objects.filter(test__engagement__product=self.test.engagement.product,
+                                                          cwe=self.cwe).exclude(id=self.id).exclude(cwe=None)
+                eng_findings_title = Finding.objects.filter(test__engagement__product=self.test.engagement.product,
+                                                            title=self.title).exclude(id=self.id)
                 total_findings = eng_findings_cwe | eng_findings_title
                 for find in total_findings:
                     if set(find.endpoints.all()) == set(self.endpoints.all()):
@@ -856,6 +888,7 @@ admin.site.register(Test_Type)
 admin.site.register(Endpoint)
 admin.site.register(Product)
 admin.site.register(Dojo_User)
+admin.site.register(UserContactInfo)
 admin.site.register(Notes)
 admin.site.register(Report)
 admin.site.register(Scan)

--- a/dojo/templates/dojo/add_user.html
+++ b/dojo/templates/dojo/add_user.html
@@ -6,7 +6,7 @@
 {% block content %}
     <h3> {{ name }} {% if to_edit %}- {{ to_edit.username }}{% endif %}</h3>
     <div class="alert alert-info" role="alert">
-        By default all users are created with an unusable password.  If a password is needed it can be set using the
+        By default all users are created with an unusable password. If a password is needed it can be set using the
         {% if to_edit %}
             <a href="{% url 'admin:auth_user_change' to_edit.id %}"><b>Admin interface</b></a>
         {% else %}
@@ -16,7 +16,14 @@
 
 
     <form class="form-horizontal" method="post">{% csrf_token %}
-        {% include "dojo/form_fields.html" with form=form %}
+        <fieldset>
+            <legend>Default Information</legend>
+            {% include "dojo/form_fields.html" with form=form %}
+        </fieldset>
+        <fieldset>
+            <legend>Additional Contact Information</legend>
+            {% include "dojo/form_fields.html" with form=contact_form %}
+        </fieldset>
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <input class="btn btn-primary" type="submit" name="add_user" value="{{ name }}"/>
@@ -29,11 +36,11 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    {%  if to_add or to_edit and not to_edit.is_staff %}
+    {% if to_add or to_edit and not to_edit.is_staff %}
         <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
         <script type="application/javascript">
             $(function () {
-                $('#id_authorized_products').chosen({'placeholder_text_multiple':'Select some products...'});
+                $('#id_authorized_products').chosen({'placeholder_text_multiple': 'Select some products...'});
             });
         </script>
     {% else %}

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -23,6 +23,9 @@
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
+            $('#id_product_manager').chosen({'placeholder_text_single': 'Select a Product Manager...'});
+            $('#id_team_manager').chosen({'placeholder_text_single': 'Select a Team Manager...'});
+            $('#id_technical_contact').chosen({'placeholder_text_single': 'Select a Technical Contact...'});
             $('#id_authorized_users').chosen({'placeholder_text_multiple': 'Select some users...'});
             $('#id_tags').chosen({
                 'placeholder_text_multiple': 'Select or add some tags...',

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -24,6 +24,9 @@
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
+            $('#id_product_manager').chosen({'placeholder_text_single': 'Select a Product Manager...'});
+            $('#id_team_manager').chosen({'placeholder_text_single': 'Select a Team Manager...'});
+            $('#id_technical_contact').chosen({'placeholder_text_single': 'Select a Technical Contact...'});
             $('#id_authorized_users').chosen({'placeholder_text_multiple': 'Select some users...'});
             $('#id_tags').chosen({
                 'placeholder_text_multiple': 'Select or add some tags...',

--- a/dojo/templates/dojo/profile.html
+++ b/dojo/templates/dojo/profile.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
-    <h3> Engineer Profile - {{ user.get_full_name }}</h3>
+    <h3> User Profile - {{ user.get_full_name }}</h3>
     <div class="row">
         <div class="col-md-7">
             <form class="form-horizontal" method="post">{% csrf_token %}
                 {% include "dojo/form_fields.html" with form=form %}
+                {% include "dojo/form_fields.html" with form=contact_form %}
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
                         <input class="btn btn-primary" type="submit" value="Submit"/>

--- a/dojo/templates/dojo/users.html
+++ b/dojo/templates/dojo/users.html
@@ -33,7 +33,7 @@
             </div>
             {% if users %}
                 <div class="clearfix">
-                    {% include "dojo/paging_snippet.html" with page=users page_size=True%}
+                    {% include "dojo/paging_snippet.html" with page=users page_size=True %}
                 </div>
                 <div class="table-responsive panel panel-default">
                     <table id="users"
@@ -42,10 +42,12 @@
                             <th class="nowrap">{% dojo_sort request 'First Name' 'first_name' %}</th>
                             <th class="nowrap">{% dojo_sort request 'Last Name' 'last_name' %}</th>
                             <th class="nowrap">{% dojo_sort request 'User Name' 'username' 'asc' %}</th>
-                            <th class="nowrap">{% dojo_sort request 'Email' 'email'%}</th>
-                            <th class="nowrap">{% dojo_sort request 'Active' 'is_active'%}</th>
-                            <th class="nowrap">{% dojo_sort request 'Staff' 'is_staff'%}</th>
-                            <th class="nowrap">{% dojo_sort request 'SuperUser' 'is_superuser'%}</th>
+                            <th class="nowrap">{% dojo_sort request 'Email' 'email' %}</th>
+                            <th class="nowrap">Title</th>
+                            <th class="nowrap">Phone Number(s)</th>
+                            <th class="nowrap">{% dojo_sort request 'Active' 'is_active' %}</th>
+                            <th class="nowrap">{% dojo_sort request 'Staff' 'is_staff' %}</th>
+                            <th class="nowrap">{% dojo_sort request 'SuperUser' 'is_superuser' %}</th>
                             <th class="nowrap">Actions</th>
                         </tr>
                         {% for u in users %}
@@ -54,6 +56,11 @@
                                 <td>{{ u.last_name }}</td>
                                 <td>{{ u.username }}</td>
                                 <td>{{ u.email }}</td>
+                                <td>{{ u.usercontactinfo.title }}</td>
+                                <td>
+                                    Phone: {{ u.usercontactinfo.phone_number }}<br/>
+                                    Cell: {{ u.usercontactinfo.cell_number }}
+                                </td>
                                 <td class="text-center">{% if u.is_active %}
                                     <i class="text-success fa fa-check"></i>{% else %}
                                     <i class="text-danger fa fa-times"></i>{% endif %}</td>
@@ -73,7 +80,7 @@
                     </table>
                 </div>
                 <div class="clearfix">
-                    {% include "dojo/paging_snippet.html" with page=users page_size=True%}
+                    {% include "dojo/paging_snippet.html" with page=users page_size=True %}
                 </div>
             {% else %}
                 <h5> No Users </h5>

--- a/dojo/templates/dojo/view_product.html
+++ b/dojo/templates/dojo/view_product.html
@@ -347,9 +347,9 @@
                     </tr>
                     <tr>
                         <td>{{ prod.prod_type }}</td>
-                        <td>{{ prod.manager | default:"Unknown" }}</td>
-                        <td>{{ prod.prod_manager | default:"Unknown" }}</td>
-                        <td>{{ prod.tech_contact | default:"Unknown" }}</td>
+                        <td>{{ prod.team_manager | default:"Unknown" }}</td>
+                        <td>{{ prod.product_manager | default:"Unknown" }}</td>
+                        <td>{{ prod.technical_contact | default:"Unknown" }}</td>
                         <td>
                             {% if prod.authorized_users.all %}
                                 <ul class="no-bullets">


### PR DESCRIPTION
Takes care of #62. Product now has three new fields: product_manager, team_manager, and technical_contact.

These replace the fields prod_manager, manager, and tech_contact.
The new fields are foreign keys to User objects.

User is now extended by UserContactInfo which adds ability to store a title, phone, cell, twitter and github for each user.

In order for these changes to work correctly, updaters must run the following commands:
`./manage.py makemigrations dojo`
`./manage.py migrate`
`./manage.py migrate_product_contacts`

Fields prod_manager, manager, and tech_contact are no longer used anywhere, but left in Product model for backwards compatibility.  They will be removed in future updates.  References to these in the project have been replaced by new fields product_manager, team_manager, and technical_contact.