### PR TITLE
Takes care of #159

### DIFF
--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -840,14 +840,6 @@ def view_engineer(request, eid):
         team = find.test.engagement.product.prod_type.name
         name = find.test.engagement.product.name
         severity = find.severity
-        if severity == 'Critical':
-            severity = 'S0'
-        elif severity == 'High':
-            severity = 'S1'
-        elif severity == 'Medium':
-            severity = 'S2'
-        else:
-            severity = 'S3'
         description = find.title
         life = date.today() - find.date
         life = life.days

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -640,6 +640,15 @@ class Finding(models.Model):
                 if not val and field in bigfields:
                     setattr(self, field, "No %s given" % field)
 
+    def severity_display(self):
+        if hasattr(settings, 'S_FINDING_SEVERITY_NAMING'):
+            if settings.S_FINDING_SEVERITY_NAMING:
+                return self.numerical_severity
+            else:
+                return self.severity
+        else:
+            return self.numerical_severity
+
     def get_breadcrumbs(self):
         bc = self.test.get_breadcrumbs()
         bc += [{'title': self.__unicode__(),

--- a/dojo/settings.dist.py
+++ b/dojo/settings.dist.py
@@ -13,7 +13,7 @@ ENABLE_DEDUPLICATION = False
 
 # True will display S0, S1, S2, ect in most places
 # False will display Critical, High, Medium, etc
-S_FINDING_SEVERITY_NAMING = True
+S_FINDING_SEVERITY_NAMING = False
 
 URL_PREFIX = ''
 

--- a/dojo/settings.dist.py
+++ b/dojo/settings.dist.py
@@ -10,6 +10,11 @@ SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 ENABLE_DEDUPLICATION = False
+
+# True will display S0, S1, S2, ect in most places
+# False will display Critical, High, Medium, etc
+S_FINDING_SEVERITY_NAMING = True
+
 URL_PREFIX = ''
 
 # Uncomment this line if you enable SSL

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -232,10 +232,10 @@
                                     class="table table-bordered table-condensed table-striped table-400">
                                 <tr>
                                     <th>Product</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
                                     <th>Total</th>
                                 </tr>
                                 {% for t in top_ten_products %}
@@ -271,7 +271,7 @@
                                             {{ finding.test.engagement.product.name|truncatechars:20 }}
                                         </span>
                                     </td>
-                                    <td>{{ finding.numerical_severity }}</td>
+                                    <td>{{ finding.severity_display }}</td>
                                     <td><a href="{% url 'view_finding' finding.id %}"
                                            title="{{ finding.title }}">{{ finding.title|truncatechars:20 }}</a></td>
                                     <td>{{ finding.sql_age }}</td>
@@ -287,11 +287,11 @@
                             <table
                                     class="table table-bordered table-condensed table-striped table-600">
                                 <tr>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
-                                    <th>S4</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
+                                    <th>{% severity_value 'Info'%}</th>
                                     <th>Total</th>
                                 </tr>
                                 <tr>
@@ -307,11 +307,11 @@
                                     class="table table-bordered table-condensed table-striped table-600">
                                 <tr>
                                     <th>Product</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
-                                    <th>S4</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
+                                    <th>{% severity_value 'Info'%}</th>
                                     <th>Total</th>
 
                                 </tr>
@@ -335,11 +335,11 @@
                             <table
                                     class="table table-bordered table-condensed table-striped table-600">
                                 <tr>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
-                                    <th>S4</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
+                                    <th>{% severity_value 'Info'%}</th>
                                     <th>Total</th>
                                 </tr>
                                 <tr>
@@ -355,11 +355,11 @@
                                     class="table table-bordered table-condensed table-striped table-600">
                                 <tr>
                                     <th>Product</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
-                                    <th>S4</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
+                                    <th>{% severity_value 'Info'%}</th>
                                     <th>Total</th>
 
                                 </tr>
@@ -385,11 +385,11 @@
                             <table
                                     class="table table-bordered table-condensed table-striped table-600">
                                 <tr>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
-                                    <th>S4</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
+                                    <th>{% severity_value 'Info'%}</th>
                                     <th>Total</th>
                                 </tr>
                                 <tr>
@@ -405,11 +405,11 @@
                                     class="table table-bordered table-condensed table-striped table-600">
                                 <tr>
                                     <th>Product</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
-                                    <th>S4</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
+                                    <th>{% severity_value 'Info'%}</th>
                                     <th>Total</th>
 
                                 </tr>
@@ -432,10 +432,10 @@
                             <table class="table table-bordered table-condensed table-striped">
                                 <tr>
                                     <th>Weekly</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
                                     <th>Total</th>
                                     <th>Closed*</th>
                                 </tr>
@@ -456,10 +456,10 @@
                             <table class="table table-bordered table-condensed table-striped">
                                 <tr>
                                     <th>Monthly</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
                                     <th>Total</th>
                                     <th>Closed*</th>
                                 </tr>
@@ -483,10 +483,10 @@
                             <table class="table table-bordered table-condensed table-striped">
                                 <tr>
                                     <th>By Week</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
                                     <th>Total</th>
                                 </tr>
                                 {% for week in accepted_per_week|slice:'1:' %}
@@ -505,10 +505,10 @@
                             <table class="table table-bordered table-condensed table-striped">
                                 <tr>
                                     <th>By Month</th>
-                                    <th>S0</th>
-                                    <th>S1</th>
-                                    <th>S2</th>
-                                    <th>S3</th>
+                                    <th>{% severity_value 'Critical'%}</th>
+                                    <th>{% severity_value 'High'%}</th>
+                                    <th>{% severity_value 'Medium'%}</th>
+                                    <th>{% severity_value 'Low'%}</th>
                                     <th>Total</th>
                                 </tr>
                                 {% for month in accepted_per_month|slice:'1:' %}

--- a/dojo/templates/dojo/pt_counts.html
+++ b/dojo/templates/dojo/pt_counts.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load display_tags %}
 {% block add_styles %}
     form.biweekly-metrics p { display: inline-block;}
     form.biweekly-metrics input {border: 1px solid #ccc;border-radius: 4px;padding: 3px 6px;}
@@ -24,18 +25,10 @@
             <table class="table table-bordered table-condensed table-striped">
                 <thead>
                 <tr>
-                    <th>
-                        S0
-                    </th>
-                    <th>
-                        S1
-                    </th>
-                    <th>
-                        S2
-                    </th>
-                    <th>
-                        S3
-                    </th>
+                    <th>{% severity_value 'Critical' %}</th>
+                    <th>{% severity_value 'High' %}</th>
+                    <th>{% severity_value 'Medium' %}</th>
+                    <th>{% severity_value 'Low' %}</th>
                     <th>
                         Total
                     </th>
@@ -71,18 +64,10 @@
             <table class="table table-bordered table-condensed table-striped">
                 <thead>
                 <tr>
-                    <th>
-                        S0
-                    </th>
-                    <th>
-                        S1
-                    </th>
-                    <th>
-                        S2
-                    </th>
-                    <th>
-                        S3
-                    </th>
+                    <th>{% severity_value 'Critical' %}</th>
+                    <th>{% severity_value 'High' %}</th>
+                    <th>{% severity_value 'Medium' %}</th>
+                    <th>{% severity_value 'Low' %}</th>
                     <th>
                         Total
                     </th>
@@ -117,18 +102,10 @@
             <table class="table table-bordered table-condensed table-striped">
                 <thead>
                 <tr>
-                    <th>
-                        S0
-                    </th>
-                    <th>
-                        S1
-                    </th>
-                    <th>
-                        S2
-                    </th>
-                    <th>
-                        S3
-                    </th>
+                    <th>{% severity_value 'Critical' %}</th>
+                    <th>{% severity_value 'High' %}</th>
+                    <th>{% severity_value 'Medium' %}</th>
+                    <th>{% severity_value 'Low' %}</th>
                     <th>
                         Total
                     </th>
@@ -167,18 +144,10 @@
                     <th>
                         Month
                     </th>
-                    <th>
-                        S0
-                    </th>
-                    <th>
-                        S1
-                    </th>
-                    <th>
-                        S2
-                    </th>
-                    <th>
-                        S3
-                    </th>
+                    <th>{% severity_value 'Critical' %}</th>
+                    <th>{% severity_value 'High' %}</th>
+                    <th>{% severity_value 'Medium' %}</th>
+                    <th>{% severity_value 'Low' %}</th>
                     <th>
                         Opened in Month
                     </th>
@@ -237,18 +206,10 @@
                     <th>
                         Product
                     </th>
-                    <th>
-                        S0
-                    </th>
-                    <th>
-                        S1
-                    </th>
-                    <th>
-                        S2
-                    </th>
-                    <th>
-                        S3
-                    </th>
+                    <th>{% severity_value 'Critical' %}</th>
+                    <th>{% severity_value 'High' %}</th>
+                    <th>{% severity_value 'Medium' %}</th>
+                    <th>{% severity_value 'Low' %}</th>
                     <th>
                         Total
                     </th>
@@ -307,7 +268,7 @@
                         <td class="nowrap">{{ finding.date }}</td>
                         <td>{% if finding.severity == "Critical" or finding.severity == "High" %}
                             <p class="text-danger">
-                        {% else %}<p>{% endif %}{{ finding.numerical_severity }}</p></td>
+                        {% else %}<p>{% endif %}{{ finding.severity_display }}</p></td>
                         <td>{{ finding.age }}</td>
                         <td><a
                                 href="{% url 'view_product' finding.test.engagement.product.id %}"

--- a/dojo/templates/dojo/research_metrics.html
+++ b/dojo/templates/dojo/research_metrics.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
+{% load display_tags %}
 {% block content %}
     <table id="content" class="table-full">
         <tr id="open">
@@ -8,10 +9,10 @@
                 <table class="table table-bordered table-condensed table-striped table-400">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     {% for key, value in month_all_by_product.items %}
@@ -29,10 +30,10 @@
                 <table class="table table-bordered table-condensed table-striped table-400">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     {% for key, value in week_all_by_product.items %}
@@ -52,10 +53,10 @@
                 <table class="table table-bordered table-condensed table-striped table-400">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
 
                     </tr>
@@ -74,10 +75,10 @@
                 <table class="table table-bordered table-condensed table-striped table-400">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     {% for key, value in week_verified_by_product.items %}
@@ -96,10 +97,10 @@
                 <h4>Remaining Issues</h4>
                 <table class="table table-bordered table-condensed table-striped table-400">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     <tr>
@@ -117,10 +118,10 @@
                 <table class="table table-bordered table-condensed table-striped table-400">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     {% for key, value in remaining_by_product.items %}
@@ -139,10 +140,10 @@
                 <h4>Average Time to Close (Days)</h4>
                 <table class="table table-bordered table-condensed table-striped table-400">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                     </tr>
                     <tr>
                         <td> {{ time_to_close.S0 }} </td>

--- a/dojo/templates/dojo/simple_metrics.html
+++ b/dojo/templates/dojo/simple_metrics.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
-
+{% load display_tags %}
 {% block content %}
 
     <h2> {{ name }}</h2>
@@ -21,21 +21,11 @@
                     <th>
                         Total
                     </th>
-                    <th>
-                        S0
-                    </th>
-                    <th>
-                        S1
-                    </th>
-                    <th>
-                        S2
-                    </th>
-                    <th>
-                        S3
-                    </th>
-                    <th>
-                        S4
-                    </th>
+                    <th>{% severity_value 'Critical' %}</th>
+                    <th>{% severity_value 'High' %}</th>
+                    <th>{% severity_value 'Medium' %}</th>
+                    <th>{% severity_value 'Low' %}</th>
+                    <th>{% severity_value 'Info' %}</th>
                     <th>
                         Opened This Month
                     </th>

--- a/dojo/templates/dojo/view_engineer.html
+++ b/dojo/templates/dojo/view_engineer.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
+{% load display_tags %}
 {% load static from staticfiles %}
 {% block add_styles %}
     #chart_div3 .flot-x-axis .tickLabel, #chart_div4 .flot-x-axis .tickLabel
@@ -119,10 +120,10 @@
                     <table class="table table-striped ">
                         <tr>
                             <th>Product</th>
-                            <th>S0</th>
-                            <th>S1</th>
-                            <th>S2</th>
-                            <th>S3</th>
+                            <th>{% severity_value 'Critical' %}</th>
+                            <th>{% severity_value 'High' %}</th>
+                            <th>{% severity_value 'Medium' %}</th>
+                            <th>{% severity_value 'Low' %}</th>
                             <th>Total</th>
                         </tr>
                         {% for t in update %}
@@ -151,10 +152,10 @@
                 <!-- /.panel-heading -->
                 <table class="table table-striped table-bordered">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     <tr>
@@ -168,10 +169,10 @@
                 <table class="table table-striped table-bordered">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
 
                     </tr>
@@ -196,10 +197,10 @@
                 <!-- /.panel-heading -->
                 <table class="table table-striped table-bordered">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     <tr>
@@ -213,10 +214,10 @@
                 <table class="table table-striped table-bordered">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
 
                     </tr>
@@ -243,10 +244,10 @@
                 <!-- /.panel-heading -->
                 <table class="table table-bordered table-striped">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     <tr>
@@ -260,10 +261,10 @@
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
 
                     </tr>
@@ -288,10 +289,10 @@
                 <!-- /.panel-heading -->
                 <table class="table table-bordered table-striped">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     <tr>
@@ -305,10 +306,10 @@
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
 
                     </tr>
@@ -336,10 +337,10 @@
                 <!-- /.panel-heading -->
                 <table class="table table-bordered  table-striped">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     <tr>
@@ -353,10 +354,10 @@
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
 
                     </tr>
@@ -381,10 +382,10 @@
                 <!-- /.panel-heading -->
                 <table class="table table-bordered table-striped ">
                     <tr>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     <tr>
@@ -398,10 +399,10 @@
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th> Product</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
 
                     </tr>
@@ -428,10 +429,10 @@
                 <table class="table table-bordered  table-striped">
                     <tr>
                         <th>Weekly</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                         <th>Closed</th>
                     </tr>
@@ -446,10 +447,10 @@
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th>Monthly</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                         <th>Closed</th>
                     </tr>
@@ -471,10 +472,10 @@
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th>By Week</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     {% for items in week_a_stuff %}
@@ -488,10 +489,10 @@
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th>By Month</th>
-                        <th>S0</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
+                        <th>{% severity_value 'Critical' %}</th>
+                        <th>{% severity_value 'High' %}</th>
+                        <th>{% severity_value 'Medium' %}</th>
+                        <th>{% severity_value 'Low' %}</th>
                         <th>Total</th>
                     </tr>
                     {% for items in a_total %}
@@ -515,10 +516,10 @@
                     <table class="table table-bordered table-striped">
                         <tr>
                             <th>Product</th>
-                            <th>S0</th>
-                            <th>S1</th>
-                            <th>S2</th>
-                            <th>S3</th>
+                            <th>{% severity_value 'Critical' %}</th>
+                            <th>{% severity_value 'High' %}</th>
+                            <th>{% severity_value 'Medium' %}</th>
+                            <th>{% severity_value 'Low' %}</th>
                             <th>Total</th>
                         </tr>
                         {% for t in total_update %}
@@ -538,7 +539,7 @@
         <div class="col-lg-6">
             <div class="panel panel-default table-responsive">
                 <div class="panel-heading">
-                    Age of Open Issues (S0 and S1 Only)
+                    Age of Open Issues ({% severity_value 'Critical' %} and {% severity_value 'High' %} Only)
                 </div>
                 <table class="table table-bordered table-striped">
                     <tr>

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -10,8 +10,9 @@ from django.utils.safestring import mark_safe, SafeData
 from django.utils.text import normalize_newlines
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
+from django.conf import settings
 
-from dojo.models import Check_List, FindingImage, FindingImageAccessToken
+from dojo.models import Check_List, FindingImage, FindingImageAccessToken, Finding
 
 register = template.Library()
 
@@ -146,3 +147,11 @@ def pic_token(context, image, size):
     token = FindingImageAccessToken(user=user, image=image, size=size)
     token.save()
     return reverse('download_finding_pic', args=[token.token])
+
+
+@register.simple_tag
+def severity_value(value):
+    if settings.S_FINDING_SEVERITY_NAMING:
+        return Finding.get_numerical_severity(value)
+
+    return value

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -151,7 +151,8 @@ def pic_token(context, image, size):
 
 @register.simple_tag
 def severity_value(value):
-    if settings.S_FINDING_SEVERITY_NAMING:
-        return Finding.get_numerical_severity(value)
+    if hasattr(settings, 'S_FINDING_SEVERITY_NAMING'):
+        if settings.S_FINDING_SEVERITY_NAMING:
+            return Finding.get_numerical_severity(value)
 
     return value


### PR DESCRIPTION
Now able to set the following `settings.py` attribute:

    S_FINDING_SEVERITY_NAMING = True/False

True will display S0, S1, S2, ect in most places
False will display Critical, High, Medium, etc

For new installations the attribute defaults to False.
For existing installations the attribute needs to be added.