### PR TITLE
Create ability to import scans from the tastypie API

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -846,6 +846,8 @@ class ImportScanResource(MultipartResource, Resource):
             bundle.data['active'] = True
         if 'verified' not in bundle.data:
             bundle.data['verified'] = True
+        if 'tags' not in bundle.data:
+            bundle.data['tags'] = ""
 
         bundle.obj.__setattr__('engagement', Engagement.objects.get(id=bundle.data['eid']))
 

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -6,7 +6,8 @@ from tastypie.api import Api
 from dojo import views
 from dojo.ajax import StubFindingResource as ajax_stub_finding_resource
 from dojo.api import UserResource, ProductResource, EngagementResource, \
-    TestResource, FindingResource, ScanSettingsResource, ScanResource, StubFindingResource, FindingTemplateResource
+    TestResource, FindingResource, ScanSettingsResource, ScanResource, \
+    StubFindingResource, FindingTemplateResource, ImportScanResource
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
 from dojo.endpoint.urls import urlpatterns as endpoint_urls
 from dojo.engagement.urls import urlpatterns as eng_urls
@@ -38,6 +39,7 @@ v1_api.register(FindingTemplateResource())
 v1_api.register(ScanSettingsResource())
 v1_api.register(ScanResource())
 v1_api.register(StubFindingResource())
+v1_api.register(ImportScanResource())
 # v1_api.register(IPScanResource())
 
 ajax_api = Api(api_name='v1_a')


### PR DESCRIPTION
I was able to implement a importscan method to the API through tastypie. I probably did some things wrong because I'm not too familiar with tastypie. Tell me if there's anything I should change.

To test it you'll want to do a command like the following:
`curl -F "file=@report123.json" -H "Authorization: ApiKey admin:xxxxxxxxxxxxxxxxxxx" -F 'scan_type=Arachni Scan' -F 'tags=testing' -F 'active=true' -F 'scan_date=11/23/2016' -F 'eid=1' http://127.0.0.1:8000/api/v1/importscan/`