### PR TITLE
Fixing Re-Importing scan functionality

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1109,19 +1109,20 @@ class ReImportScanResource(MultipartResource, Resource):
                                                   )
 
                 if len(find) == 1:
-                    if find[0].mitigated:
+                    find = find[0]
+                    if find.mitigated:
                         # it was once fixed, but now back
-                        find[0].mitigated = None
-                        find[0].mitigated_by = None
-                        find[0].active = True
-                        find[0].verified = verified
-                        find[0].save()
+                        find.mitigated = None
+                        find.mitigated_by = None
+                        find.active = True
+                        find.verified = verified
+                        find.save()
                         note = Notes(entry="Re-activated by %s re-upload." % scan_type,
                                      author=bundle.request.user)
                         note.save()
-                        find[0].notes.add(note)
+                        find.notes.add(note)
                         reactivated_count += 1
-                    new_items.append(find[0].id)
+                    new_items.append(find.id)
                 else:
                     item.test = test
                     item.date = test.target_start
@@ -1137,7 +1138,7 @@ class ReImportScanResource(MultipartResource, Resource):
 
                     if hasattr(item, 'unsaved_req_resp') and len(item.unsaved_req_resp) > 0:
                         for req_resp in item.unsaved_req_resp:
-                            burp_rr = BurpRawRequestResponse(finding=item,
+                            burp_rr = BurpRawRequestResponse(finding=find,
                                                              burpRequestBase64=req_resp["req"],
                                                              burpResponseBase64=req_resp["resp"],
                                                              )
@@ -1160,7 +1161,7 @@ class ReImportScanResource(MultipartResource, Resource):
                                                                      query=endpoint.query,
                                                                      fragment=endpoint.fragment,
                                                                      product=test.engagement.product)
-                        item.endpoints.add(ep)
+                        find.endpoints.add(ep)
 
                     if item.unsaved_tags is not None:
                         find.tags = item.unsaved_tags

--- a/dojo/api.py
+++ b/dojo/api.py
@@ -843,9 +843,6 @@ class ImportScanResource(MultipartResource, Resource):
     file = fields.FileField(attribute='file')
     engagement = fields.CharField(attribute='engagement')
 
-    @staticmethod
-
-
     class Meta:
         resource_name = 'importscan'
         fields = ['scan_date', 'minimum_severity', 'active', 'verified', 'scan_type', 'tags', 'file']
@@ -1137,6 +1134,16 @@ class ReImportScanResource(MultipartResource, Resource):
                     finding_added_count += 1
                     new_items.append(item.id)
                     find = item
+
+                    if hasattr(item, 'unsaved_req_resp') and len(item.unsaved_req_resp) > 0:
+                        for req_resp in item.unsaved_req_resp:
+                            burp_rr = BurpRawRequestResponse(finding=item,
+                                                             burpRequestBase64=req_resp["req"],
+                                                             burpResponseBase64=req_resp["resp"],
+                                                             )
+                            burp_rr.clean()
+                            burp_rr.save()
+
                     if item.unsaved_request is not None and item.unsaved_response is not None:
                         burp_rr = BurpRawRequestResponse(finding=find,
                                                          burpRequestBase64=item.unsaved_request,
@@ -1153,6 +1160,7 @@ class ReImportScanResource(MultipartResource, Resource):
                                                                      query=endpoint.query,
                                                                      fragment=endpoint.fragment,
                                                                      product=test.engagement.product)
+                        item.endpoints.add(ep)
 
                     if item.unsaved_tags is not None:
                         find.tags = item.unsaved_tags

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -463,6 +463,16 @@ def re_import_scan_results(request, tid):
                         finding_added_count += 1
                         new_items.append(item.id)
                         find = item
+
+                        if hasattr(item, 'unsaved_req_resp') and len(item.unsaved_req_resp) > 0:
+                            for req_resp in item.unsaved_req_resp:
+                                burp_rr = BurpRawRequestResponse(finding=item,
+                                                                 burpRequestBase64=req_resp["req"],
+                                                                 burpResponseBase64=req_resp["resp"],
+                                                                 )
+                                burp_rr.clean()
+                                burp_rr.save()
+
                         if item.unsaved_request is not None and item.unsaved_response is not None:
                             burp_rr = BurpRawRequestResponse(finding=find,
                                                              burpRequestBase64=item.unsaved_request,
@@ -479,6 +489,7 @@ def re_import_scan_results(request, tid):
                                                                          query=endpoint.query,
                                                                          fragment=endpoint.fragment,
                                                                          product=t.engagement.product)
+                            item.endpoints.add(ep)
 
                         if item.unsaved_tags is not None:
                             find.tags = item.unsaved_tags

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -438,19 +438,20 @@ def re_import_scan_results(request, tid):
                                                       )
 
                     if len(find) == 1:
-                        if find[0].mitigated:
+                        find = find[0]
+                        if find.mitigated:
                             # it was once fixed, but now back
-                            find[0].mitigated = None
-                            find[0].mitigated_by = None
-                            find[0].active = True
-                            find[0].verified = verified
-                            find[0].save()
+                            find.mitigated = None
+                            find.mitigated_by = None
+                            find.active = True
+                            find.verified = verified
+                            find.save()
                             note = Notes(entry="Re-activated by %s re-upload." % scan_type,
                                          author=request.user)
                             note.save()
-                            find[0].notes.add(note)
+                            find.notes.add(note)
                             reactivated_count += 1
-                        new_items.append(find[0].id)
+                        new_items.append(find.id)
                     else:
                         item.test = t
                         item.date = t.target_start
@@ -466,7 +467,7 @@ def re_import_scan_results(request, tid):
 
                         if hasattr(item, 'unsaved_req_resp') and len(item.unsaved_req_resp) > 0:
                             for req_resp in item.unsaved_req_resp:
-                                burp_rr = BurpRawRequestResponse(finding=item,
+                                burp_rr = BurpRawRequestResponse(finding=find,
                                                                  burpRequestBase64=req_resp["req"],
                                                                  burpResponseBase64=req_resp["resp"],
                                                                  )
@@ -489,7 +490,7 @@ def re_import_scan_results(request, tid):
                                                                          query=endpoint.query,
                                                                          fragment=endpoint.fragment,
                                                                          product=t.engagement.product)
-                            item.endpoints.add(ep)
+                            find.endpoints.add(ep)
 
                         if item.unsaved_tags is not None:
                             find.tags = item.unsaved_tags


### PR DESCRIPTION
I found a bug where when you went to re-import a scan it wouldn't add the endpoints or requests for the new findings.