### PR TITLE
Fix213 - deletecheckboxes on add

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1089,6 +1089,17 @@ class AddDojoUserForm(forms.ModelForm):
     authorized_products = forms.ModelMultipleChoiceField(
         queryset=Product.objects.all(), required=False,
         help_text='Select the products this user should have access to.')
+    class Meta:
+        model = Dojo_User
+        fields = ['username', 'first_name', 'last_name', 'email', 'is_active']
+        exclude = ['password', 'last_login', 'groups',
+                   'date_joined', 'user_permissions',
+                   'is_staff', 'is_superuser']
+                   
+class EditDojoUserForm(forms.ModelForm):
+    authorized_products = forms.ModelMultipleChoiceField(
+        queryset=Product.objects.all(), required=False,
+        help_text='Select the products this user should have access to.')
 
     class Meta:
         model = Dojo_User

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -12,7 +12,7 @@ from pytz import timezone
 from tastypie.models import ApiKey
 
 from dojo.filters import UserFilter
-from dojo.forms import DojoUserForm, AddDojoUserForm, DeleteUserForm, APIKeyForm, UserContactInfoForm
+from dojo.forms import DojoUserForm, AddDojoUserForm, DeleteUserForm, APIKeyForm, UserContactInfoForm, EditDojoUserForm
 from dojo.models import Product, Dojo_User, UserContactInfo
 from dojo.utils import get_page_items, add_breadcrumb, get_alerts
 
@@ -203,7 +203,7 @@ def add_user(request):
 def edit_user(request, uid):
     user = get_object_or_404(Dojo_User, id=uid)
     authed_products = Product.objects.filter(authorized_users__in=[user])
-    form = AddDojoUserForm(instance=user, initial={'authorized_products': authed_products})
+    form = EditDojoUserForm(instance=user, initial={'authorized_products': authed_products})
     try:
         user_contact = UserContactInfo.objects.get(user=user)
     except UserContactInfo.DoesNotExist:


### PR DESCRIPTION
The second of three fixes for #213. This would bifurcate the adduser form, so that the checkboxes for staff and su only appear on edituser and not on adduser. This is in case #213 is actually a feature, not a bug, though I'm not entirely sure why.