### PR TITLE
Fix213 - make staff and su only enableable through admin interface

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1092,10 +1092,10 @@ class AddDojoUserForm(forms.ModelForm):
 
     class Meta:
         model = Dojo_User
-        fields = ['username', 'first_name', 'last_name', 'email', 'is_active',
-                  'is_staff', 'is_superuser']
+        fields = ['username', 'first_name', 'last_name', 'email', 'is_active']
         exclude = ['password', 'last_login', 'groups',
-                   'date_joined', 'user_permissions']
+                   'date_joined', 'user_permissions',
+                   'is_staff', 'is_superuser']
 
 
 class DeleteUserForm(forms.ModelForm):


### PR DESCRIPTION
The third fix for #213. Now staff and su checkboxes will not show up at all on add or edit user. This one inspired by [a comment](https://github.com/OWASP/django-DefectDojo/issues/213#issuecomment-276766777) by @devGregA which seemed to imply that the proper behavior is for staff and su permissions to only be settable through the admin interface.