### PR TITLE
Jira and order update

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -162,7 +162,7 @@ class ProductForm(forms.ModelForm):
                            help_text="Add tags that help describe this product.  "
                                      "Choose from the list or add new tags.  Press TAB key to add.")
     prod_type = forms.ModelChoiceField(label='Product Type',
-                                       queryset=Product_Type.objects.all(),
+                                       queryset=Product_Type.objects.all().order_by('name'),
                                        required=True)
 
     authorized_users = forms.ModelMultipleChoiceField(
@@ -510,9 +510,9 @@ class DeleteEngagementForm(forms.ModelForm):
 
 
 class TestForm(forms.ModelForm):
-    test_type = forms.ModelChoiceField(queryset=Test_Type.objects.all())
+    test_type = forms.ModelChoiceField(queryset=Test_Type.objects.all().order_by('name'))
     environment = forms.ModelChoiceField(
-        queryset=Development_Environment.objects.all())
+        queryset=Development_Environment.objects.all().order_by('name'))
     target_start = forms.DateTimeField(widget=forms.TextInput(
         attrs={'class': 'datepicker'}))
     target_end = forms.DateTimeField(widget=forms.TextInput(

--- a/dojo/management/commands/push_to_jira_update.py
+++ b/dojo/management/commands/push_to_jira_update.py
@@ -1,0 +1,45 @@
+from django.contrib.contenttypes.models import ContentType
+
+from django.core.management.base import BaseCommand
+from pytz import timezone
+
+from dojo.models import Finding, JIRA_PKey, JIRA_Issue, Product, Engagement, Alerts
+import dojo.settings as settings
+from datetime import datetime
+from auditlog.models import LogEntry
+from jira import JIRA
+from jira.exceptions import JIRAError
+from dojo.utils import add_comment, add_epic, add_issue, update_epic, update_issue, close_epic
+from django.core.urlresolvers import get_resolver, reverse
+
+locale = timezone(settings.TIME_ZONE)
+
+"""
+Author: Aaron Weaver
+This script will locate open, active findings and update them in Jira. Useful if you need to make bulk changes with Jira:
+"""
+
+
+class Command(BaseCommand):
+    help = 'No input commands for Jira bulk update.'
+
+    def handle(self, *args, **options):
+
+        findings = Finding.objects.exclude(jira_issue__isnull=True)
+        findings = findings.filter(verified=True, active=True)
+
+        for finding in findings:
+            #prod = Product.objects.get(engagement=Engagement.objects.get(test=finding.test))
+            #jpkey = JIRA_PKey.objects.get(product=prod)
+            #jira_conf = jpkey.conf
+
+            #j_issue = JIRA_Issue.objects.get(finding=finding)
+            #print "Finding ID: " + str(finding.id)
+            #print finding.title
+            #jira_id = j_issue.jira_id
+            print "Checking issue:" + str(finding.id)
+            update_issue(finding, finding.status(), True)
+            print "########\n"
+
+            #if save:
+            #    finding.save()

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -966,8 +966,8 @@ class JIRA_Conf(models.Model):
 class JIRA_Issue(models.Model):
     jira_id =  models.CharField(max_length=200)
     jira_key =  models.CharField(max_length=200)
-    finding = models.ForeignKey(Finding, null=True, blank=True)
-    engagement = models.ForeignKey(Engagement, null=True, blank=True)
+    finding = models.OneToOneField(Finding, null=True, blank=True)
+    engagement = models.OneToOneField(Engagement, null=True, blank=True)
 
 class JIRA_PKey(models.Model):
     project_key = models.CharField(max_length=200, blank=True)
@@ -978,6 +978,19 @@ class JIRA_PKey(models.Model):
     enable_engagement_epic_mapping = models.BooleanField(default=False, blank=True)
     push_notes = models.BooleanField(default=False, blank=True)
 
+class Alerts(models.Model):
+    description = models.CharField(max_length=2000, null=True)
+    url =  models.URLField(max_length=2000, null=True)
+    source = models.CharField(max_length=15,
+                            choices=(
+                                ('Jira', 'Jira'),
+                                ('Asynchimport', 'Asynch Import'),
+                                ('Generic', 'Generic')),
+                            default='Generic')
+    icon = models.CharField(max_length=25, default='icon-user-check')
+    user_id = models.ForeignKey(User, null=True, editable=False)
+    created = models.DateTimeField(null=False, editable=False, default=now)
+    display_date = models.DateTimeField(null=False, default=now)
 
 # Register for automatic logging to database
 auditlog.register(Dojo_User)
@@ -1015,6 +1028,8 @@ admin.site.register(Report)
 admin.site.register(Scan)
 admin.site.register(ScanSettings)
 admin.site.register(IPScan)
+admin.site.register(Alerts)
+admin.site.register(JIRA_Issue)
 
 watson.register(Product)
 watson.register(Test)


### PR DESCRIPTION
Added improved Jira error handling, including bubbling up asynch events to the alerts UI. Modified the models to only allow one jira issue per finding. Updated a couple lists to order alphabetically.