### PR TITLE
addresses #184 - new graph drawer on engagement view page.  shows ope…

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -23,7 +23,7 @@ At this point bower may ask you to select from different versions of packages, c
 
 Next you can run: ::
 
-    ./manage.py collectstatic --no-input
+    ./manage.py collectstatic --noinput
 
 If you are in your production system, you will need to restart gunicorn and celery to make sure the latest code is
 being used by both.

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -287,6 +287,7 @@ def view_engagement(request, eid):
                    'closed_findings': closed_findings,
                    'accepted_findings': accepted_findings,
                    'new_findings': new_verified_findings,
+                   'start_date': start_date,
                    })
 
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1,7 +1,7 @@
 # #  engagements
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.contrib.auth.models import User
 from django.conf import settings
@@ -143,7 +143,7 @@ def edit_engagement(request, eid):
             pass
         if hasattr(settings, "ENABLE_JIRA"):
             if settings.ENABLE_JIRA:
-                if JIRA_PKey.objects.filter(product= eng.product).count() != 0:
+                if JIRA_PKey.objects.filter(product=eng.product).count() != 0:
                     jform = JIRAFindingForm(prefix='jiraform', enabled=enabled)
                 else:
                     jform = None
@@ -196,8 +196,8 @@ def view_engagement(request, eid):
     try:
         jissue = JIRA_Issue.objects.get(engagement=eng)
     except:
-            jissue = None
-            pass
+        jissue = None
+        pass
     try:
         jconf = JIRA_PKey.objects.get(product=eng.product).conf
     except:
@@ -235,6 +235,46 @@ def view_engagement(request, eid):
     else:
         fpage = None
 
+    # ----------
+
+    try:
+        start_date = Finding.objects.filter(test__engagement__product=eng.product).order_by('date')[:1][0].date
+    except:
+        start_date = localtz.localize(datetime.today())
+
+    end_date = localtz.localize(datetime.today())
+
+    risk_acceptances = Risk_Acceptance.objects.filter(engagement__in=Engagement.objects.filter(product=eng.product))
+
+    accepted_findings = [finding for ra in risk_acceptances
+                         for finding in ra.accepted_findings.all()]
+
+    week_date = end_date - timedelta(days=7)  # seven days and /newer are considered "new"
+
+    new_verified_findings = Finding.objects.filter(test__engagement__product=eng.product,
+                                                   date__range=[week_date, end_date],
+                                                   false_p=False,
+                                                   verified=True,
+                                                   duplicate=False,
+                                                   out_of_scope=False).order_by("date")
+
+    open_findings = Finding.objects.filter(test__engagement__product=eng.product,
+                                           date__range=[start_date, end_date],
+                                           false_p=False,
+                                           verified=True,
+                                           duplicate=False,
+                                           out_of_scope=False,
+                                           active=True,
+                                           mitigated__isnull=True)
+
+    closed_findings = Finding.objects.filter(test__engagement__product=eng.product,
+                                             date__range=[start_date, end_date],
+                                             false_p=False,
+                                             verified=True,
+                                             duplicate=False,
+                                             out_of_scope=False,
+                                             mitigated__isnull=False)
+
     return render(request, 'dojo/view_eng.html',
                   {'eng': eng, 'tests': tests,
                    'findings': fpage, 'enabled': enabled,
@@ -243,6 +283,10 @@ def view_engagement(request, eid):
                    'risks_accepted': risks_accepted,
                    'can_add_risk': len(eng_findings),
                    'jissue': jissue, 'jconf': jconf,
+                   'open_findings': open_findings,
+                   'closed_findings': closed_findings,
+                   'accepted_findings': accepted_findings,
+                   'new_findings': new_verified_findings,
                    })
 
 

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load get_config_setting %}
+{% load humanize %}
+{% load static from staticfiles %}
+{% block add_styles %}
+    .graph {min-height: 158px;}
+    h3 { margin-top: 5px; margin-bottom: 5px; font-size: 20px; line-height: 22px;}
+{% endblock %}
 {% block content %}
     <!-- start status bread crums -->
     <ul id="progress-crumbs" class="breadcrumb">
@@ -35,51 +41,167 @@
                 </h3>
 
                 <div class="dropdown pull-right">
-                    <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
-                            data-toggle="dropdown" aria-expanded="true">
-                        <span class="fa fa-bars"></span>
-                        <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
-                        <li role="presentation">
-                            <a class="" href="{% url 'edit_engagement' eng.id %}">
-                                <i class="fa fa-pencil-square-o"></i> Edit Engagement
-                            </a>
-                        </li>
+                    <div class="btn-group">
+                        <button class="btn btn-primary clickable panel-collapsed">
+                            <span><i class="fa fa-bar-chart"></i></span>
+                        </button>
+                        <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
+                                data-toggle="dropdown" aria-expanded="true">
+                            <span class="fa fa-bars"></span>
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
+                            <li role="presentation">
+                                <a class="" href="{% url 'edit_engagement' eng.id %}">
+                                    <i class="fa fa-pencil-square-o"></i> Edit Engagement
+                                </a>
+                            </li>
 
-                        <li role="presentation">
-                            {% if eng.active %}
-                                <a class="" href="{% url 'close_engagement' eng.id %}">
-                                    <i class="fa fa-close"></i> Close Engagement
+                            <li role="presentation">
+                                {% if eng.active %}
+                                    <a class="" href="{% url 'close_engagement' eng.id %}">
+                                        <i class="fa fa-close"></i> Close Engagement
+                                    </a>
+                                {% else %}
+                                    <a class="" href="{% url 'reopen_engagement' eng.id %}">
+                                        <i class="fa fa-undo"></i> Reopen Engagement
+                                    </a>
+                                {% endif %}
+                            </li>
+                            <li role="presentation">
+                                <a href="{% url 'engagement_report' eng.id %}">
+                                    <i class="fa fa-file-text-o"></i> Report
                                 </a>
-                            {% else %}
-                                <a class="" href="{% url 'reopen_engagement' eng.id %}">
-                                    <i class="fa fa-undo"></i> Reopen Engagement
+                            </li>
+                            <li role="presentation">
+                                <a href="{% url 'engagement_ics' eng.id %}">
+                                    <i class="fa fa-calendar-plus-o"></i> Add To Calendar
                                 </a>
-                            {% endif %}
-                        </li>
-                        <li role="presentation">
-                            <a href="{% url 'engagement_report' eng.id %}">
-                                <i class="fa fa-file-text-o"></i> Report
-                            </a>
-                        </li>
-                        <li role="presentation">
-                            <a href="{% url 'engagement_ics' eng.id %}">
-                                <i class="fa fa-calendar-plus-o"></i> Add To Calendar
-                            </a>
-                        </li>
-                        <li role="presentation">
-                            <a href="{% url 'action_history' eng|content_type eng.id %}">
-                                <i class="fa fa-history"></i> View History
-                            </a>
-                        </li>
-                        <li role="separator" class="divider"></li>
-                        <li role="presentation">
-                            <a class="text-danger" href="{% url 'delete_engagement' eng.id %}">
-                                <i class="fa fa-trash-o"></i> Delete Engagement
-                            </a>
-                        </li>
-                    </ul>
+                            </li>
+                            <li role="presentation">
+                                <a href="{% url 'action_history' eng|content_type eng.id %}">
+                                    <i class="fa fa-history"></i> View History
+                                </a>
+                            </li>
+                            <li role="separator" class="divider"></li>
+                            <li role="presentation">
+                                <a class="text-danger" href="{% url 'delete_engagement' eng.id %}">
+                                    <i class="fa fa-trash-o"></i> Delete Engagement
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="panel-body product-graphs">
+            <div class="col-md-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <i class="fa fa-bug fa-2x"></i>
+
+                                <div class="pull-right inline-block text-right">
+                                    <span class=" fa-2x">{{ open_findings|length }}</span>
+                                    <span><a href="{% url 'open_findings' %}?test__engagement__product={{ prod.id }}">open
+                                        finding{{ open_findings|length|pluralize }} <i
+                                                class="fa fa-arrow-circle-right"></i></a>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body">
+                        <div id="open_findings" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i title="Accepted since {{ start_date }}"
+                           class="text-info fa fa-info-circle"></i>
+                        <small>Opened since {{ start_date|date:"D., M. d, Y" }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <i class="fa fa-fire-extinguisher fa-2x"></i>
+
+                                <div class="text-right pull-right">
+                                    <span class="fa-2x">{{ closed_findings|length }}</span>
+                                    <span><a href="{% url 'closed_findings' %}?test__engagement__product={{ prod.id }}">closed
+                                        finding{{ closed_findings|length|pluralize }}. <i
+                                                class="fa fa-arrow-circle-right"></i></a>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body">
+                        <div id="closed_findings" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i title="Accepted since {{ start_date }}"
+                           class="text-info fa fa-info-circle"></i>
+                        <small>Closed since {{ start_date|date:"D., M. d, Y" }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <i class="fa fa-check fa-2x"></i>
+
+                                <div class="pull-right text-right">
+                                    <span class="fa-2x">{{ accepted_findings|length }}</span>
+                                    <span><a
+                                            href="{% url 'accepted_findings' %}?test__engagement__product={{ prod.id }}">Accepted
+                                    findings. <i class="fa fa-arrow-circle-right"></i></a>
+                                </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body">
+                        <div id="reported_findings" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i title="Accepted since {{ start_date }}"
+                           class="text-info fa fa-info-circle"></i>
+                        <small>Accepted since {{ start_date|date:"D., M. d, Y" }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <i class="fa fa-crosshairs fa-2x"></i>
+
+                                <div class="pull-right inline-block text-right">
+                                    <span class=" fa-2x">{{ new_findings|length }}</span>
+                                    <span><a
+                                            href="{% url 'open_findings' %}?test__engagement__product={{ prod.id }}&amp;date=2">new
+                                        finding{{ new_findings|length|pluralize }} <i
+                                                class="fa fa-arrow-circle-right"></i></a>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body">
+                        <div id="new_findings" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i title="Found in the last 7 days."
+                           class="text-info fa fa-info-circle"></i>
+                        <small>Found in the last 7 days.</small>
+                    </div>
                 </div>
             </div>
         </div>
@@ -167,22 +289,22 @@
             </div>
         {% endif %}
     </div>
- {% if jissue and jconf %}
-    <div class="row to_highlight">
-        <div class="col-md-12">
-            <div class="panel panel-default endpoints table-responsive">
-                <div class="panel-heading">
-                    <h4>JIRA Link
-                        <span class="pull-right"><a data-toggle="collapse" href="#jira_link"><i
-                                class="glyphicon glyphicon-chevron-up"></i></a></span>
-                    </h4>
-                </div>
-                    <div id="jira_link" class="panel-body endpoint-panel table-responsive collapse in">
-                      <a href="{{jconf.url}}/browse/{{jissue.jira_key}}"> {{jconf.url}}/browse/{{jissue.jira_key}} </a>
+    {% if jissue and jconf %}
+        <div class="row to_highlight">
+            <div class="col-md-12">
+                <div class="panel panel-default endpoints table-responsive">
+                    <div class="panel-heading">
+                        <h4>JIRA Link
+                            <span class="pull-right"><a data-toggle="collapse" href="#jira_link"><i
+                                    class="glyphicon glyphicon-chevron-up"></i></a></span>
+                        </h4>
                     </div>
+                    <div id="jira_link" class="panel-body endpoint-panel table-responsive collapse in">
+                        <a href="{{ jconf.url }}/browse/{{ jissue.jira_key }}"> {{ jconf.url }}/browse/{{ jissue.jira_key }} </a>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
     {% endif %}
     <div class="row">
         <div id="tests" class="col-md-12">
@@ -388,73 +510,648 @@
         </div>
 
     </div>
-{% if enabled %}
- <div class="row">
-        <div id="finding" class="col-md-12">
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h4> Findings</h4>
-                </div>
-        {% if findings %}
-            <table id="test_findings" class="table-bordered table table-condensed table-hover">
+    {% if enabled %}
+        <div class="row">
+            <div id="finding" class="col-md-12">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h4> Findings</h4>
+                    </div>
+                    {% if findings %}
+                        <table id="test_findings" class="table-bordered table table-condensed table-hover">
 
 
-                <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Severity</th>
-                    <th>Reporter</th>
-                    <th>Mitigation Date</th>
-                    <th>Verified</th>
-                    <th>Active</th>
-                    {% if "ENABLE_JIRA"|get_config_setting %}
-                    <th>Jira</th>
+                            <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Severity</th>
+                                <th>Reporter</th>
+                                <th>Mitigation Date</th>
+                                <th>Verified</th>
+                                <th>Active</th>
+                                {% if "ENABLE_JIRA"|get_config_setting %}
+                                    <th>Jira</th>
+                                {% endif %}
+                                <th>Actions</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for finding in findings %}
+                                <tr class="{% if finding.active %}active_finding{% else %}inactive_finding{% endif %}">
+                                    <td><a href="{% url 'view_finding' finding.id %}">{{ finding.title }}</a></td>
+                                    <td>{% if finding.severity == "Critical" or finding.severity == "High" %}
+                                        <span class="text-error">
+                                    {% else %}<span>{% endif %}{{ finding.severity }}</span></td>
+                                    <td>{{ finding.reporter.username }}</td>
+                                    <td>{{ finding.mitigated }}</td>
+                                    <td>{{ finding.verified }}</td>
+                                    <td>{{ finding.active }}</td>
+                                    {% if "ENABLE_JIRA"|get_config_setting %}
+                                        <td>
+                                            <a href="{{ finding.jira_conf.url }}/browse/{{ finding.jira.jira_key }}"
+                                               target="_blank"> {{ finding.jira.jira_key }} </a>
+                                        </td>
+                                    {% endif %}
+                                    <td>
+                                        <div class="btn-group">
+                                            <a class="btn btn-sm btn-primary"
+                                               href="{% url 'view_finding' finding.id %}">View</a>
+                                            <a class="btn btn-sm btn-warning"
+                                               href="{% url 'edit_finding' finding.id %}">Edit</a>
+                                            <a class="btn btn-sm btn-danger delete-finding"
+                                               href="{% url 'delete_finding' finding.id %}">Delete</a>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                        <div class="panel-body {% if findings %}show{% else %}hidden{% endif %}">
+                            {% include "dojo/paging_snippet.html" with page=findings %}
+                        </div>
+                    {% else %}
+                        <div class="panel-body">
+                            <p class="text-center">No findings found.</p>
+                        </div>
                     {% endif %}
-                    <th>Actions</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for finding in findings %}
-                    <tr class="{% if finding.active %}active_finding{% else %}inactive_finding{% endif %}">
-                        <td><a href="{% url 'view_finding' finding.id %}">{{ finding.title }}</a></td>
-                        <td>{% if finding.severity == "Critical" or finding.severity == "High" %}
-                            <span class="text-error">
-                        {% else %}<span>{% endif %}{{ finding.severity }}</span></td>
-                        <td>{{ finding.reporter.username }}</td>
-                        <td>{{ finding.mitigated }}</td>
-                        <td>{{ finding.verified }}</td>
-                        <td>{{ finding.active }}</td>
-                        {% if "ENABLE_JIRA"|get_config_setting %}
-                        <td>
-                        <a href="{{finding.jira_conf.url}}/browse/{{finding.jira.jira_key}}" target="_blank"> {{finding.jira.jira_key}} </a>
-                        </td>
-                        {% endif %}
-                        <td>
-                            <div class="btn-group">
-                                <a class="btn btn-sm btn-primary"
-                                   href="{% url 'view_finding' finding.id %}">View</a>
-                                <a class="btn btn-sm btn-warning"
-                                   href="{% url 'edit_finding' finding.id %}">Edit</a>
-                                <a class="btn btn-sm btn-danger delete-finding"
-                                   href="{% url 'delete_finding' finding.id %}">Delete</a>
-                            </div>
-                        </td>
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-            <div class="panel-body {% if findings %}show{% else %}hidden{% endif %}">
-                {% include "dojo/paging_snippet.html" with page=findings %}
-            </div>
-        {% else %}
-            <div class="panel-body">
-                <p class="text-center">No findings found.</p>
-            </div>
-        {% endif %}
+                </div>
+
             </div>
 
         </div>
+    {% endif %}
+{% endblock %}
+{% block postscript %}
+    <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
+    <!-- Flot Charts JavaScript -->
+    <script src="{% static "flot/excanvas.min.js" %}"></script>
+    <script src="{% static "flot/jquery.flot.js" %}"></script>
+    <script src="{% static "flot/jquery.flot.pie.js" %}"></script>
+    <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
+    <script src="{% static "flot/jquery.flot.categories.js" %}"></script>
+    <script src="{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
+    <script src="{% static "flot/jquery.flot.time.js" %}"></script>
+    <script src="{% static "flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
+    <script type="text/javascript">
+        $(function () {
+            if (document.referrer.indexOf('simple_search') > 0) {
+                var terms = '';
+                if ($.cookie('highlight')) {
+                    terms = $.cookie('highlight').split(' ');
 
-    </div>
-{% endif %}
+                    for (var i = 0; i < terms.length; i++) {
+                        $('body').highlight(terms[i]);
+                    }
+                }
+
+                $('input#simple_search').val(terms);
+            }
+
+            $(document).on('click', '.panel-heading button.clickable', function (e) {
+                var $this = $(this);
+                if (!$this.hasClass('panel-collapsed')) {
+                    $this.parents('.panel').find('.panel-body').slideUp();
+                    $this.addClass('panel-collapsed');
+                    $this.find('i').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+                } else {
+                    $this.parents('.panel').find('.panel-body').slideDown();
+                    $this.removeClass('panel-collapsed');
+                    $this.find('i').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+                }
+            });
+
+            accepted_findings();
+            open_findings();
+            closed_findings();
+            new_findings();
+
+            $(".product-graphs").hide();
+
+        });
+
+        function accepted_findings() {
+            var critical = 0;
+            var high = 0;
+            var medium = 0;
+            var low = 0;
+            var info = 0;
+            var ticks = [
+                [0, "Critical"], [1, "High"], [2, "Medium"], [3, "Low"], [4, "Info"]
+            ];
+
+            {% for f in accepted_findings %}
+                {% if f.severity == 'Critical' %}
+                    critical += 1;
+                {% elif f.severity == 'High' %}
+                    high += 1;
+                {% elif f.severity == 'Medium' %}
+                    medium += 1;
+                {% elif f.severity == 'Low' %}
+                    low += 1;
+                {% elif f.severity == 'Info' %}
+                    info += 1;
+                {% endif %}
+            {% endfor %}
+
+            var d1 = [
+                [0, critical],
+            ];
+            var d2 = [
+                [1, high],
+            ];
+            var d3 = [
+                [2, medium],
+            ];
+            var d4 = [
+                [3, low],
+            ];
+            var d5 = [
+                [4, info],
+            ];
+
+            var data = [
+                {
+                    label: "Critical",
+                    data: d1,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 1,
+                        fillColor: "#d9534f"
+                    },
+                    color: "#d9534f"
+                },
+                {
+                    label: "High",
+                    data: d2,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 2,
+                        fillColor: "#f0ad4e"
+                    },
+                    color: "#f0ad4e"
+                },
+                {
+                    label: "Medium",
+                    data: d3,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 3,
+                        fillColor: "#f0de28"
+                    },
+                    color: "#f0de28"
+                },
+                {
+                    label: "Low",
+                    data: d4,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#337ab7"
+                    },
+                    color: "#337ab7"
+                },
+                {
+                    label: "info",
+                    data: d5,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#80699B"
+                    },
+                    color: "#80699B"
+                }
+            ];
+
+            $.plot("#reported_findings", data, {
+                series: {
+                    stack: true,
+                    bars: {
+                        show: true,
+                        barWidth: .9,
+                        'align': "center",
+                    },
+
+                },
+                grid: {
+                    hoverable: false,
+                    borderWidth: 1,
+                    borderColor: '#e7e7e7',
+
+                },
+                tooltip: false,
+                legend: {
+                    show: false,
+                    position: "ne"
+                },
+                xaxis: {
+                    ticks: ticks,
+                },
+
+            });
+        }
+        ;
+        function open_findings() {
+            var critical = 0;
+            var high = 0;
+            var medium = 0;
+            var low = 0;
+            var info = 0;
+            var ticks = [
+                [0, "Critical"], [1, "High"], [2, "Medium"], [3, "Low"], [4, "Info"]
+            ];
+
+            {% for f in open_findings %}
+                {% if f.severity == 'Critical' %}
+                    critical += 1;
+                {% elif f.severity == 'High' %}
+                    high += 1;
+                {% elif f.severity == 'Medium' %}
+                    medium += 1;
+                {% elif f.severity == 'Low' %}
+                    low += 1;
+                {% elif f.severity == 'Info' %}
+                    info += 1;
+                {% endif %}
+            {% endfor %}
+
+            var d1 = [
+                [0, critical],
+            ];
+            var d2 = [
+                [1, high],
+            ];
+            var d3 = [
+                [2, medium],
+            ];
+            var d4 = [
+                [3, low],
+            ];
+            var d5 = [
+                [4, info],
+            ];
+
+            var data = [
+                {
+                    label: "Critical",
+                    data: d1,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 1,
+                        fillColor: "#d9534f"
+                    },
+                    color: "#d9534f"
+                },
+                {
+                    label: "High",
+                    data: d2,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 2,
+                        fillColor: "#f0ad4e"
+                    },
+                    color: "#f0ad4e"
+                },
+                {
+                    label: "Medium",
+                    data: d3,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 3,
+                        fillColor: "#f0de28"
+                    },
+                    color: "#f0de28"
+                },
+                {
+                    label: "Low",
+                    data: d4,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#337ab7"
+                    },
+                    color: "#337ab7"
+                },
+                {
+                    label: "info",
+                    data: d5,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#80699B"
+                    },
+                    color: "#80699B"
+                }
+            ];
+
+            $.plot("#open_findings", data, {
+                series: {
+                    stack: true,
+                    bars: {
+                        show: true,
+                        barWidth: .9,
+                        'align': "center",
+                    },
+
+                },
+                grid: {
+                    hoverable: false,
+                    borderWidth: 1,
+                    borderColor: '#e7e7e7',
+
+                },
+                tooltip: false,
+                legend: {
+                    show: false,
+                    position: "ne"
+                },
+                xaxis: {
+                    ticks: ticks,
+                },
+
+            });
+        }
+        ;
+        function closed_findings() {
+            var critical = 0;
+            var high = 0;
+            var medium = 0;
+            var low = 0;
+            var info = 0;
+            var ticks = [
+                [0, "Critical"], [1, "High"], [2, "Medium"], [3, "Low"], [4, "Info"]
+            ];
+
+            {% for f in closed_findings %}
+                {% if f.severity == 'Critical' %}
+                    critical += 1;
+                {% elif f.severity == 'High' %}
+                    high += 1;
+                {% elif f.severity == 'Medium' %}
+                    medium += 1;
+                {% elif f.severity == 'Low' %}
+                    low += 1;
+                {% elif f.severity == 'Info' %}
+                    info += 1;
+                {% endif %}
+            {% endfor %}
+
+            var d1 = [
+                [0, critical],
+            ];
+            var d2 = [
+                [1, high],
+            ];
+            var d3 = [
+                [2, medium],
+            ];
+            var d4 = [
+                [3, low],
+            ];
+            var d5 = [
+                [4, info],
+            ];
+
+            var data = [
+                {
+                    label: "Critical",
+                    data: d1,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 1,
+                        fillColor: "#d9534f"
+                    },
+                    color: "#d9534f"
+                },
+                {
+                    label: "High",
+                    data: d2,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 2,
+                        fillColor: "#f0ad4e"
+                    },
+                    color: "#f0ad4e"
+                },
+                {
+                    label: "Medium",
+                    data: d3,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 3,
+                        fillColor: "#f0de28"
+                    },
+                    color: "#f0de28"
+                },
+                {
+                    label: "Low",
+                    data: d4,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#337ab7"
+                    },
+                    color: "#337ab7"
+                },
+                {
+                    label: "info",
+                    data: d5,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#80699B"
+                    },
+                    color: "#80699B"
+                }
+            ];
+
+            $.plot("#closed_findings", data, {
+                series: {
+                    stack: true,
+                    bars: {
+                        show: true,
+                        barWidth: .9,
+                        'align': "center",
+                    },
+
+                },
+                grid: {
+                    hoverable: false,
+                    borderWidth: 1,
+                    borderColor: '#e7e7e7',
+
+                },
+                tooltip: false,
+                legend: {
+                    show: false,
+                    position: "ne"
+                },
+                xaxis: {
+                    ticks: ticks,
+                },
+
+            });
+        }
+        ;
+        function new_findings() {
+            var critical = 0;
+            var high = 0;
+            var medium = 0;
+            var low = 0;
+            var info = 0;
+            var ticks = [
+                [0, "Critical"], [1, "High"], [2, "Medium"], [3, "Low"], [4, "Info"]
+            ];
+
+            {% for f in new_findings %}
+                {% if f.severity == 'Critical' %}
+                    critical += 1;
+                {% elif f.severity == 'High' %}
+                    high += 1;
+                {% elif f.severity == 'Medium' %}
+                    medium += 1;
+                {% elif f.severity == 'Low' %}
+                    low += 1;
+                {% elif f.severity == 'Info' %}
+                    info += 1;
+                {% endif %}
+            {% endfor %}
+
+            var d1 = [
+                [0, critical],
+            ];
+            var d2 = [
+                [1, high],
+            ];
+            var d3 = [
+                [2, medium],
+            ];
+            var d4 = [
+                [3, low],
+            ];
+            var d5 = [
+                [4, info],
+            ];
+
+            var data = [
+                {
+                    label: "Critical",
+                    data: d1,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 1,
+                        fillColor: "#d9534f"
+                    },
+                    color: "#d9534f"
+                },
+                {
+                    label: "High",
+                    data: d2,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 2,
+                        fillColor: "#f0ad4e"
+                    },
+                    color: "#f0ad4e"
+                },
+                {
+                    label: "Medium",
+                    data: d3,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 3,
+                        fillColor: "#f0de28"
+                    },
+                    color: "#f0de28"
+                },
+                {
+                    label: "Low",
+                    data: d4,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#337ab7"
+                    },
+                    color: "#337ab7"
+                },
+                {
+                    label: "info",
+                    data: d5,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#80699B"
+                    },
+                    color: "#80699B"
+                }
+            ];
+
+            $.plot("#new_findings", data, {
+                series: {
+                    stack: true,
+                    bars: {
+                        show: true,
+                        barWidth: .9,
+                        'align': "center",
+                    },
+
+                },
+                grid: {
+                    hoverable: false,
+                    borderWidth: 1,
+                    borderColor: '#e7e7e7',
+
+                },
+                tooltip: false,
+                legend: {
+                    show: false,
+                    position: "ne"
+                },
+                xaxis: {
+                    ticks: ticks,
+                },
+
+            });
+        }
+        ;
+    </script>
 {% endblock %}


### PR DESCRIPTION
…n, closed, accepted, and new finding graphs based on severity.  Additionally the view engagement page already has a paged listing of all verified, open, non duplicate findings at the bottom of the page.

<img width="1560" alt="screen shot 2017-02-23 at 9 08 12 pm" src="https://cloud.githubusercontent.com/assets/233694/23289051/ec3cdbf2-fa0c-11e6-9c68-feed2e1668c9.png">

<img width="1562" alt="screen shot 2017-02-23 at 9 06 37 pm" src="https://cloud.githubusercontent.com/assets/233694/23289056/f0c2d9b0-fa0c-11e6-8586-2ae65dac2606.png">

<img width="1641" alt="screen shot 2017-02-23 at 9 07 05 pm" src="https://cloud.githubusercontent.com/assets/233694/23289059/f6e55af2-fa0c-11e6-999e-8d91303ad9a7.png">
