### PR TITLE
api syntax fix

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -121,7 +121,7 @@ class MultipartResource(object):
             data.update(request.FILES)
             return data
 
-        return super(MultiPartResource, self).deserialize(request, data, format)
+        return super(MultipartResource, self).deserialize(request, data, format)
 
 # Authentication class - this only allows for header auth, no url parms allowed
 # like parent class.


### PR DESCRIPTION
Hi,

There is typo in MultipartResource class name which breaks the API.
It would be great if it could be fixed in the master version. :)

All the best,
Istvan