### PR TITLE
Fix queryset errors

### DIFF
--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -368,7 +368,7 @@ def search(request, tid):
     templates = TemplateFindingFilter(request.GET, queryset=templates).qs
     paged_templates = get_page_items(request, templates, 25)
     title_words = [word
-                   for finding in templates.qs
+                   for finding in templates
                    for word in finding.title.split() if len(word) > 2]
 
     title_words = sorted(set(title_words))

--- a/dojo/views.py
+++ b/dojo/views.py
@@ -31,7 +31,7 @@ def action_history(request, cid, oid):
 
     history = LogEntry.objects.filter(content_type=ct, object_pk=obj.id).order_by('-timestamp')
     history = LogEntryFilter(request.GET, queryset=history)
-    paged_history = get_page_items(request, history, 25)
+    paged_history = get_page_items(request, history.qs, 25)
     add_breadcrumb(parent=obj, title="Action History", top_level=False, request=request)
     return render(request, 'dojo/action_history.html',
                   {"history": paged_history,


### PR DESCRIPTION
This PR fixes a bug with a missing qs reference in the history view as well as a bug that makes the search view throw an error due to a double qs reference.