### PR TITLE
nmap XML file parsing support

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -389,18 +389,19 @@ DefectDojo has the ability to import reports from other security tools.  Current
 
 1. Burp XML
 2. Nessus (CSV, XML)
-3. Nexpose XML 2.0
-4. ZAP XML
-5. Veracode Detailed XML Report
-6. Checkmarx Detailed XML Report
-7. AppSpider Vulnerabilities Summary XML Report (VulnerabilitiesSummary.xml)
-8. Arachni Scanner JSON Report
-9. Visual Code Grepper XML or CSV
-10. OWASP Dependency Check XML
-11. Retire.js JavaScript Scan JSON
-12. Node Security Platform JSON
-12. Qualys XML
-13. Generic Findings in CSV format
+3. Nmap (XML)
+4. Nexpose XML 2.0
+5. ZAP XML
+6. Veracode Detailed XML Report
+7. Checkmarx Detailed XML Report
+8. AppSpider Vulnerabilities Summary XML Report (VulnerabilitiesSummary.xml)
+9. Arachni Scanner JSON Report
+10. Visual Code Grepper XML or CSV
+11. OWASP Dependency Check XML
+12. Retire.js JavaScript Scan JSON
+13. Node Security Platform JSON
+14. Qualys XML
+15. Generic Findings in CSV format
 
 
 The importers analyze each report and create new Findings for each item reported.  DefectDojo collapses duplicate

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -228,7 +228,7 @@ class Product_TypeProductForm(forms.ModelForm):
 
 
 class ImportScanForm(forms.Form):
-    SCAN_TYPE_CHOICES = (("Burp Scan", "Burp Scan"), ("Nessus Scan", "Nessus Scan"), ("Nexpose Scan", "Nexpose Scan"),
+    SCAN_TYPE_CHOICES = (("Burp Scan", "Burp Scan"), ("Nessus Scan", "Nessus Scan"), ("nmap Scan", "nmap Scan"), ("Nexpose Scan", "Nexpose Scan"),
                          ("AppSpider Scan", "AppSpider Scan"), ("Veracode Scan", "Veracode Scan"),
                          ("Checkmarx Scan", "Checkmarx Scan"), ("ZAP Scan", "ZAP Scan"),
                          ("Arachni Scan", "Arachni Scan"), ("VCG Scan", "VCG Scan"),

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -228,7 +228,7 @@ class Product_TypeProductForm(forms.ModelForm):
 
 
 class ImportScanForm(forms.Form):
-    SCAN_TYPE_CHOICES = (("Burp Scan", "Burp Scan"), ("Nessus Scan", "Nessus Scan"), ("nmap Scan", "nmap Scan"), ("Nexpose Scan", "Nexpose Scan"),
+    SCAN_TYPE_CHOICES = (("Burp Scan", "Burp Scan"), ("Nessus Scan", "Nessus Scan"), ("Nmap Scan", "Nmap Scan"), ("Nexpose Scan", "Nexpose Scan"),
                          ("AppSpider Scan", "AppSpider Scan"), ("Veracode Scan", "Veracode Scan"),
                          ("Checkmarx Scan", "Checkmarx Scan"), ("ZAP Scan", "ZAP Scan"),
                          ("Arachni Scan", "Arachni Scan"), ("VCG Scan", "VCG Scan"),

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -416,10 +416,12 @@ class CWE(models.Model):
 
 class Endpoint(models.Model):
     protocol = models.CharField(null=True, blank=True, max_length=10,
-                                help_text="The communication protocl such as 'http', 'ftp', etc.")
+                                help_text="The communication protocol such as 'http', 'ftp', etc.")
     host = models.CharField(null=True, blank=True, max_length=500,
                             help_text="The host name or IP address, you can also include the port number. For example"
                                       "'127.0.0.1', '127.0.0.1:8080', 'localhost', 'yourdomain.com'.")
+    fqdn = models.CharField(null=True, blank=True, max_length=500)
+    port = models.IntegerField(null=True, blank=True, help_text="The network port associated with the endpoint.")
     path = models.CharField(null=True, blank=True, max_length=500,
                             help_text="The location of the resource, it should start with a '/'. For example"
                                       "/endpoint/420/edit")
@@ -438,14 +440,19 @@ class Endpoint(models.Model):
         from urlparse import uses_netloc
 
         netloc = self.host
+        fqdn = self.fqdn
+        port = self.port
         scheme = self.protocol
         url = self.path if self.path else ''
         query = self.query
         fragment = self.fragment
 
+        if port:
+            netloc += ':%s' % port
+
         if netloc or (scheme and scheme in uses_netloc and url[:2] != '//'):
             if url and url[:1] != '/': url = '/' + url
-            if scheme:
+            if scheme and scheme in uses_netloc and url[:2] != '//':
                 url = '//' + (netloc or '') + url
             else:
                 url = (netloc or '') + url

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -18,6 +18,7 @@
         <li><b>Burp XML</b> - When the Burp report is generated, we recommend selecting the option to Base64 encode both the request and
             response fields. These fields will be processed and made available in the Finding view page.</li>
         <li><b>Tenable Nessus</b> - Reports can be imported in the CSV, and .nessus (XML) report formats.</li>
+        <li><b>nmap</b> - XML output (use -oX)</li>
         <li><b>Rapid7 Nexpose XML 2.0</b> - Use the full XML export template from Nexpose.</li>
         <li><b>Rapid7 AppSpider</b> - Use the VulnerabilitiesSummary.xml file found in the zipped report download.</li>
         <li><b>Veracode Detailed XML Report</b></li>

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -18,7 +18,7 @@
         <li><b>Burp XML</b> - When the Burp report is generated, we recommend selecting the option to Base64 encode both the request and
             response fields. These fields will be processed and made available in the Finding view page.</li>
         <li><b>Tenable Nessus</b> - Reports can be imported in the CSV, and .nessus (XML) report formats.</li>
-        <li><b>nmap</b> - XML output (use -oX)</li>
+        <li><b>Nmap</b> - XML output (use -oX)</li>
         <li><b>Rapid7 Nexpose XML 2.0</b> - Use the full XML export template from Nexpose.</li>
         <li><b>Rapid7 AppSpider</b> - Use the VulnerabilitiesSummary.xml file found in the zipped report download.</li>
         <li><b>Veracode Detailed XML Report</b></li>

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -198,7 +198,7 @@
         <div class="col-md-12">
             <div class="panel panel-default endpoints table-responsive">
                 <div class="panel-heading">
-                    <h4>Vulnerable Endpoints / Systems
+                    <h4>Affected Endpoints / Systems
                         <span class="pull-right"><a data-toggle="collapse" href="#vuln_endpoints"><i
                                 class="glyphicon glyphicon-chevron-up"></i></a></span>
                     </h4>

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -1,5 +1,6 @@
 from dojo.tools.burp.parser import BurpXmlParser
 from dojo.tools.nessus.parser import NessusCSVParser, NessusXMLParser
+from dojo.tools.nmap.parser import NmapXMLParser
 from dojo.tools.nexpose.parser import NexposeFullXmlParser
 from dojo.tools.veracode.parser import VeracodeXMLParser
 from dojo.tools.zap.parser import ZapXmlParser
@@ -27,6 +28,8 @@ def import_parser_factory(file, test):
             parser = NessusCSVParser(file, test)
         elif filename.endswith("xml") or filename.endswith("nessus"):
             parser = NessusXMLParser(file, test)
+    elif scan_type == "nmap Scan":
+        parser = NmapXMLParser(file, test)
     elif scan_type == "Nexpose Scan":
         parser = NexposeFullXmlParser(file, test)
     elif scan_type == "Veracode Scan":

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -28,7 +28,7 @@ def import_parser_factory(file, test):
             parser = NessusCSVParser(file, test)
         elif filename.endswith("xml") or filename.endswith("nessus"):
             parser = NessusXMLParser(file, test)
-    elif scan_type == "nmap Scan":
+    elif scan_type == "Nmap Scan":
         parser = NmapXMLParser(file, test)
     elif scan_type == "Nexpose Scan":
         parser = NexposeFullXmlParser(file, test)

--- a/dojo/tools/nmap/__init__.py
+++ b/dojo/tools/nmap/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'patriknordlen'

--- a/dojo/tools/nmap/parser.py
+++ b/dojo/tools/nmap/parser.py
@@ -15,7 +15,7 @@ class NmapXMLParser(object):
         root = nscan.getroot()
 
         if 'nmaprun' not in root.tag:
-            raise NamespaceErr("This doesn't seem to be a valid nmap xml file.")
+            raise NamespaceErr("This doesn't seem to be a valid Nmap xml file.")
         dupes = {}
         for host in root.iter("host"):
             ip = host.find("address[@addrtype='ipv4']").attrib['addr']

--- a/dojo/tools/nmap/parser.py
+++ b/dojo/tools/nmap/parser.py
@@ -1,0 +1,59 @@
+from xml.dom import NamespaceErr
+import lxml.etree as le
+import os
+import csv
+import re
+from dojo.models import Endpoint, Finding
+from pprint import pprint
+
+__author__ = 'patriknordlen'
+
+class NmapXMLParser(object):
+    def __init__(self, file, test):
+        nscan = le.parse(file)
+        root = nscan.getroot()
+
+        if 'nmaprun' not in root.tag:
+            raise NamespaceErr("This doesn't seem to be a valid nmap xml file.")
+        dupes = {}
+        for host in root.iter("host"):
+            ip = host.find("address[@addrtype='ipv4']").attrib['addr']
+            fqdn = host.find("hostnames/hostname[@type='PTR']").attrib['name'] if host.find("hostnames/hostname[@type='PTR']") is not None else None
+
+            for portelem in host.xpath("ports/port[state/@state='open']"):
+                port = portelem.attrib['portid']
+                protocol = portelem.attrib['protocol']
+
+                title = "Open port: %s/%s" % (port, protocol)
+                
+                description = "%s:%s A service was found to be listening on this port." % (ip, port)
+
+                if portelem.find('service'):
+                    if hasattr(portelem.find('service'),'product'):
+                        serviceinfo = " (%s%s)" % (portelem.find('service').attrib['product'], " "+portelem.find('service').attrib['version'] if hasattr(portelem.find('service'),'version') else "")
+                    else:
+                        serviceinfo = ""
+                    description += " It was identified as '%s%s'." % (portelem.find('service').attrib['name'], serviceinfo)
+                description += '\n\n'
+
+                severity = "Info"
+
+                dupe_key = port
+
+                if dupe_key in dupes:
+                    find = dupes[dupe_key]
+                    if description is not None:
+                        find.description += description
+                else:
+                    find = Finding(title=title,
+                                    test=test,
+                                    active=False,
+                                    verified=False,
+                                    description=description,
+                                    severity=severity,
+                                    numerical_severity=Finding.get_numerical_severity(severity))
+                    find.unsaved_endpoints = list()
+                    dupes[dupe_key] = find
+
+                find.unsaved_endpoints.append(Endpoint(host=ip, fqdn=fqdn, port=port, protocol=protocol))
+        self.items = dupes.values()

--- a/dojo/tools/nmap/parser.py
+++ b/dojo/tools/nmap/parser.py
@@ -10,7 +10,8 @@ __author__ = 'patriknordlen'
 
 class NmapXMLParser(object):
     def __init__(self, file, test):
-        nscan = le.parse(file)
+        parser = le.XMLParser(resolve_entities=False)
+        nscan = le.parse(file, parser)
         root = nscan.getroot()
 
         if 'nmaprun' not in root.tag:
@@ -28,7 +29,7 @@ class NmapXMLParser(object):
                 
                 description = "%s:%s A service was found to be listening on this port." % (ip, port)
 
-                if portelem.find('service'):
+                if portelem.find('service') is not None:
                     if hasattr(portelem.find('service'),'product'):
                         serviceinfo = " (%s%s)" % (portelem.find('service').attrib['product'], " "+portelem.find('service').attrib['version'] if hasattr(portelem.find('service'),'version') else "")
                     else:


### PR DESCRIPTION
This PR addresses issue #218.

It adds a parser for nmap XML files, and creates informational findings with basic details about identified services from them.

It also extends the Endpoint model to include port and fqdn in order to improve filtering and reporting possibilities in the future.