### PR TITLE
View and filter tests/engagements and users in calendar

### DIFF
--- a/dojo/engagement/urls.py
+++ b/dojo/engagement/urls.py
@@ -4,7 +4,8 @@ from dojo.engagement import views
 
 urlpatterns = [
     #  engagements and calendar
-    url(r'^calendar$', views.calendar, name='calendar'),
+    url(r'^calendar$', views.engagement_calendar, name='calendar'),
+    url(r'^calendar/engagements$', views.engagement_calendar, name='engagement_calendar'),
     url(r'^engagement$', views.engagement, name='engagement'),
     url(r'^engagement/new$', views.new_engagement, name='new_eng'),
     url(r'^engagement/(?P<eid>\d+)$', views.view_engagement,

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -55,7 +55,7 @@ def engagement_calendar(request):
         filters.append(Q(lead__in=leads))
         engagements = Engagement.objects.filter(reduce(operator.or_, filters))
 
-    add_breadcrumb(title="Calendar", top_level=True, request=request)
+    add_breadcrumb(title="Engagement Calendar", top_level=True, request=request)
     return render(request, 'dojo/calendar.html', {
         'caltype': 'engagements',
         'leads': request.GET.getlist('lead', ''),

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -23,7 +23,7 @@ from dojo.forms import CheckForm, \
 from dojo.models import Finding, Product, Engagement, Test, \
     Check_List, Test_Type, Notes, \
     Risk_Acceptance, Development_Environment, BurpRawRequestResponse, Endpoint, \
-    JIRA_PKey, JIRA_Conf, JIRA_Issue, Cred_User, Cred_Mapping
+    JIRA_PKey, JIRA_Conf, JIRA_Issue, Cred_User, Cred_Mapping, Dojo_User
 from dojo.tools.factory import import_parser_factory
 from dojo.utils import get_page_items, add_breadcrumb, handle_uploaded_threat, \
     FileIterWrapper, get_cal_event, message, get_system_setting
@@ -42,11 +42,17 @@ logger = logging.getLogger(__name__)
 
 @user_passes_test(lambda u: u.is_staff)
 @cache_page(60 * 5)  # cache for 5 minutes
-def calendar(request):
-    engagements = Engagement.objects.all()
+def engagement_calendar(request):
+    if not 'lead' in request.GET or '*' in request.GET.getlist('lead'):
+        engagements = Engagement.objects.all()
+    else:
+        engagements = Engagement.objects.filter(lead__username__in=request.GET.getlist('lead', ''))
     add_breadcrumb(title="Calendar", top_level=True, request=request)
     return render(request, 'dojo/calendar.html', {
-        'engagements': engagements})
+        'caltype': 'engagements',
+        'leads': request.GET.getlist('lead', ''),
+        'engagements': engagements,
+        'users': Dojo_User.objects.all()})
 
 
 @user_passes_test(lambda u: u.is_staff)

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -568,7 +568,7 @@ class TestForm(forms.ModelForm):
 
     class Meta:
         model = Test
-        fields = ['test_type', 'target_start', 'target_end', 'environment', 'percent_complete', 'tags']
+        fields = ['test_type', 'target_start', 'target_end', 'environment', 'percent_complete', 'tags', 'lead']
 
 
 class DeleteTestForm(forms.ModelForm):

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -243,7 +243,7 @@
                             {% endif %}
                             {% if request.user.is_staff %}
                                 <li>
-                                    <a href="{% url 'calendar' %}"><i class="fa fa-calendar fa-fw"></i>
+                                    <a href="{% url 'engagement_calendar' %}"><i class="fa fa-calendar fa-fw"></i>
                                         <span>Calendar</span></a>
                                 </li>
                                 <li>

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -15,9 +15,10 @@
                 </div>
                 <div class="col-lg-6" style="width:400px;">
                     <select data-placeholder="All users" multiple id="lead" name="lead" class="chosen-select">
-                        <option value="*">All users</option>
+                        <option value="0">All users</option>
+                        <option value="-1">Unassigned</option>
                         {% for u in users %}
-                            <option value="{{ u.username }}">{{ u.username }}</option>
+                            <option value="{{ u.id }}">{{ u.username }}</option>
                         {% endfor %}
                     </select>
                 </div>

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -32,7 +32,7 @@
     <br/><br/>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
     <script>
           $(function () {
             $(".chosen-select").chosen({disable_search_threshold: 10});

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -36,11 +36,11 @@
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
     <script>
           $(function () {
+            $('#caltype').change(function() { $('#calfilter').attr('action', '/calendar/' + $(this).val()); });
             $(".chosen-select").chosen({disable_search_threshold: 10});
-            $('#caltype').val('{{ caltype }}');
+            $('#caltype').val('{{ caltype }}'); $('#caltype').trigger('change');
             $('#lead').val([{% for lead in leads %} '{{ lead }}', {% endfor %}]);
             $('.chosen-select').trigger('chosen:updated');
-            $('#caltype').change(function() { $('#calfilter').attr('action', '/calendar/' + $(this).val()); });
             $('#calendar').fullCalendar({
                 header: {
                     left: 'prev,next today',

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -52,7 +52,7 @@
                     {% if caltype == 'tests' %}
                         {% for t in tests %}
                             {
-                                title: '{{t.engagement.product.name}}: {{ t.engagement.name|default:"Unknown" }} - {{ t.test_type }} ({{ t.engagement.lead }})',
+                                title: '{{t.engagement.product.name}}: {{ t.engagement.name|default:"Unknown" }} - {{ t.test_type }} ({{ t.lead|default:"Unassigned" }})',
                                 start: '{{t.target_start|date:"c"}}',
                                 end: '{{t.target_end|date:"c"}}',
                                 url: '{% url 'view_test' t.id %}',

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -1,11 +1,45 @@
 {% extends 'base.html' %}
+{% load static from staticfiles %}
+{% block add_css %}
+    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+{% endblock %}
 {% block content %}
+    <form method="GET" id="calfilter" action="/calendar">
+        <div class="container-fluid chosen-container side-by-side">
+            <div class="row">
+                <div class="col-lg-6" style="width:200px;">
+                    <select data-placeholder="Calendar type" id="caltype" class="chosen-select">
+                        <option value="engagements">Engagements</option>
+                        <option value="tests">Tests</option>
+                    </select>
+                </div>
+                <div class="col-lg-6" style="width:400px;">
+                    <select data-placeholder="All users" multiple id="lead" name="lead" class="chosen-select">
+                        <option value="*">All users</option>
+                        {% for u in users %}
+                            <option value="{{ u.username }}">{{ u.username }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-lg-6">
+                    <button class="btn btn-primary" type="submit">Apply</button>
+                </div>
+            </div>
+        </div>
+    </form>
+    <br/><br/>
     <div id="calendar"></div>
     <br/><br/>
 {% endblock %}
 {% block postscript %}
+    <script type="application/javascript" src="{% static "chosen/chosen.jquery.js" %}"></script>
     <script>
-        $(function () {
+          $(function () {
+            $(".chosen-select").chosen({disable_search_threshold: 10});
+            $('#caltype').val('{{ caltype }}');
+            $('#lead').val([{% for lead in leads %} '{{ lead }}', {% endfor %}]);
+            $('.chosen-select').trigger('chosen:updated');
+            $('#caltype').change(function() { $('#calfilter').attr('action', '/calendar/' + $(this).val()); });
             $('#calendar').fullCalendar({
                 header: {
                     left: 'prev,next today',
@@ -15,16 +49,29 @@
                 editable: false,
                 eventLimit: true, // allow "more" link when too many events
                 events: [
-                    {% for e in engagements %}
-                        {
-                            title: '{{e.product.name}}: {{ e.name|default:"Unknown" }}',
-                            start: '{{e.target_start|date:"c"}}',
-                            end: '{{e.target_end|date:"c"}}',
-                            url: '{% url 'view_engagement' e.id %}',
-                            color: {%  if e.active %}'#337ab7'{% else %}'#b9b9b9'{% endif %},
-                            overlap: true
-                        },
-                    {%  endfor %}
+                    {% if caltype == 'tests' %}
+                        {% for t in tests %}
+                            {
+                                title: '{{t.engagement.product.name}}: {{ t.engagement.name|default:"Unknown" }} - {{ t.test_type }} ({{ t.engagement.lead }})',
+                                start: '{{t.target_start|date:"c"}}',
+                                end: '{{t.target_end|date:"c"}}',
+                                url: '{% url 'view_test' t.id %}',
+                                color: {%  if t.engagement.active %}'#337ab7'{% else %}'#b9b9b9'{% endif %},
+                                overlap: true
+                            },
+                        {%  endfor %}                    
+                    {% else %}
+                        {% for e in engagements %}
+                            {
+                                title: '{{e.product.name}}: {{ e.name|default:"Unknown" }} ({{ e.lead|default:"Unassigned" }})',
+                                start: '{{e.target_start|date:"c"}}',
+                                end: '{{e.target_end|date:"c"}}',
+                                url: '{% url 'view_engagement' e.id %}',
+                                color: {%  if e.active %}'#337ab7'{% else %}'#b9b9b9'{% endif %},
+                                overlap: true
+                            },
+                        {%  endfor %}
+                    {% endif %}
                 ]
             });
 

--- a/dojo/test/urls.py
+++ b/dojo/test/urls.py
@@ -4,6 +4,7 @@ from dojo.test import views
 
 urlpatterns = [
     #  tests
+    url(r'^calendar/tests$', views.test_calendar, name='test_calendar'),
     url(r'^test/(?P<tid>\d+)$', views.view_test,
         name='view_test'),
     url(r'^test/(?P<tid>\d+)/ics$', views.test_ics,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -173,7 +173,7 @@ def test_calendar(request):
             filters.append(Q(lead__isnull=True))
         filters.append(Q(lead__in=leads))
         tests = Test.objects.filter(reduce(operator.or_, filters))
-    add_breadcrumb(title="Calendar", top_level=True, request=request)
+    add_breadcrumb(title="Test Calendar", top_level=True, request=request)
     return render(request, 'dojo/calendar.html', {
         'caltype': 'tests',
         'leads': request.GET.getlist('lead', ''),


### PR DESCRIPTION
This PR addresses issue #237.

It adds functionality in the calendar to view calendars by tests or engagements, as well as filtering those by a set of users or unassigned engagements/tests.

![image](https://user-images.githubusercontent.com/5840042/28171693-82400aa8-67e9-11e7-8f19-5c2a8eada212.png)

