### PR TITLE
Minor bugfixes

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -753,6 +753,14 @@ class ReportAuthedFindingFilter(DojoFilter):
             self.form.fields['test__engagement__product'].queryset = Product.objects.filter(
                 authorized_users__in=[self.user])
 
+    @property
+    def qs(self):
+        parent = super(ReportAuthedFindingFilter, self).qs
+        if self.user.is_staff:
+            return parent
+        else:
+            return parent.filter(test__engagement__product__authorized_users__in=[self.user])
+
     class Meta:
         model = Finding
         exclude = ['date', 'cwe', 'url', 'description', 'mitigation', 'impact',

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -728,7 +728,7 @@ class Finding(models.Model):
                 return self.severity
 
         except:
-            return self.numerical_severity
+            return self.severity
 
     def get_breadcrumbs(self):
         bc = self.test.get_breadcrumbs()


### PR DESCRIPTION
This PR addresses #330 and #336.

#330 - the default severity naming is now non-numerical if no system settings have been set.
#336 - users will now only see findings from products that they're authorised to view in the findings widget in the report builder.