### PR TITLE
wrap pre-tags in the finding view

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -642,6 +642,11 @@ td .fa-fw {
     background-color: transparent;
     border: 0px;
     padding: 0px;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
 }
 
 h4.finding-title {


### PR DESCRIPTION
The PR wraps the text in pre-tags in the finding view which improves the legibility of findings.