### PR TITLE
Fix errors/outdated information

### DIFF
--- a/docs/dojo-production.rst
+++ b/docs/dojo-production.rst
@@ -11,7 +11,7 @@ This guide will walk you through how to setup DefectDojo for running in producti
 
   virtualenv dojo
 
-  source my_project/bin/activate
+  source dojo/bin/activate
 
 **Install Dojo**
 

--- a/docs/dojo-production.rst
+++ b/docs/dojo-production.rst
@@ -89,20 +89,36 @@ Everyone feels a little differently about nginx settings, so here are the barebo
   upstream django {
     server 127.0.0.1:8001; 
   }
-
+  
   server {
     listen 80;
+    return 301 https://$host$request_uri;
+  }
+
+  server {
+    listen 443;
+    server_name <YOUR_SERVER_NAME>;
+    
+    client_max_body_size 500m; # To accommodate large scan files
+    
+    ssl_certificate           <PATH_TO_CRT>;
+    ssl_certificate_key       <PATH_TO_KEY>;
+    
+    ssl on;
+    
+    <YOUR_SSL_SETTINGS> # ciphers, options, logging, etc
+    
     location /static/ {
-        alias   /data/prod_dojo/django-DefectDojo/static/;
+        alias   <PATH_TO_DOJO>/django-DefectDojo/static/;
     }
 
     location /media/ {
-        alias   /data/prod_dojo/django-DefectDojo/media/;
+        alias   <PATH_TO_DOJO>/django-DefectDojo/media/;
     }
 
     location / {
         uwsgi_pass django;
-        include     /data/prod_dojo/django-DefectDojo/wsgi_params;
+        include     <PATH_TO_DOJO>/django-DefectDojo/wsgi_params;
     }
   }
 

--- a/docs/dojo-production.rst
+++ b/docs/dojo-production.rst
@@ -19,7 +19,7 @@ This guide will walk you through how to setup DefectDojo for running in producti
 
   cd django-DefectDojo
 
-  ./install.bash
+  ./setup.bash
 
 **Install Uwsgi**
 
@@ -82,27 +82,28 @@ It is recommended that you use an Upstart job or a @restart cron job to launch u
 
 *NGINX Configuration*
 
-Everyone feels a little differently about nginx settings, so here are the barebones to add your to your nginx configuration to proxy uwsgi:
+Everyone feels a little differently about nginx settings, so here are the barebones to add your to your nginx configuration to proxy uwsgi. Make sure to modify the filesystem paths if needed:
 
 .. code-block:: json
 
   upstream django {
-   
     server 127.0.0.1:8001; 
   }
 
-  location /dojo/static/ {
-      alias   /data/prod_dojo/django-DefectDojo/static/;
-  }
+  server {
+    listen 80;
+    location /static/ {
+        alias   /data/prod_dojo/django-DefectDojo/static/;
+    }
 
-  location /dojo/media/ {
-      alias   /data/prod_dojo/django-DefectDojo/media/;
-  }
+    location /media/ {
+        alias   /data/prod_dojo/django-DefectDojo/media/;
+    }
 
-
-  location /dojo {
-      uwsgi_pass django;
-      include     /data/prod_dojo/django-DefectDojo/wsgi_params;
+    location / {
+        uwsgi_pass django;
+        include     /data/prod_dojo/django-DefectDojo/wsgi_params;
+    }
   }
 
 *That's it!*


### PR DESCRIPTION
There were errors in the nginx configuration with a fresh clone from master. I've corrected these, added a note to double-check the location paths, and updated the name of the install script to reflect the new name (setup.bash vs install.bash).