### PR TITLE
Fix PDF Report Generation When Host Header Contains a Different External Port

### DIFF
--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -43,8 +43,11 @@ def report_url_resolver(request):
         url_resolver = request.META['HTTP_X_FORWARDED_PROTO'] + "://" +  request.META['HTTP_X_FORWARDED_FOR']
     except:
         hostname = request.META['HTTP_HOST']
-        url_resolver = request.scheme + "://" + hostname[:hostname.find(":")]
-
+        port_index = hostname.find(":")
+        if port_index != -1:
+            url_resolver = request.scheme + "://" + hostname[:port_index]
+        else:
+            url_resolver = request.scheme + "://" + hostname
     return url_resolver
 
 

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -48,7 +48,7 @@ def report_url_resolver(request):
             url_resolver = request.scheme + "://" + hostname[:port_index]
         else:
             url_resolver = request.scheme + "://" + hostname
-    return url_resolver
+    return url_resolver + ":" + request.META['SERVER_PORT']
 
 
 def report_builder(request):

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -42,7 +42,8 @@ def report_url_resolver(request):
     try:
         url_resolver = request.META['HTTP_X_FORWARDED_PROTO'] + "://" +  request.META['HTTP_X_FORWARDED_FOR']
     except:
-        url_resolver = request.scheme + "://" + request.META['HTTP_HOST']
+        hostname = request.META['HTTP_HOST']
+        url_resolver = request.scheme + "://" + hostname[:hostname.find(":")]
 
     return url_resolver
 


### PR DESCRIPTION
This patch fixes a bug that occurred when generating a report from the Engagements page when the client is using a different port in the host header than Defect Dojo is listening on locally (e.g., port forwarding/SSH tunneling, but it could happen in other scenarios). The backend task that attempts to generate the PDF report would try to connect to the external port and the connection would be refused. Now, we simply ignore the port by checking if there is a ":" in the host header and stripping it out if it does exist.
