### PR TITLE
Fix a typo and a permissions issue with non-interactive bower install

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -286,7 +286,8 @@ fi
 
 if [ $(id -u) = 0 ]; then
     adduser --disabled-password --gecos "DefectDojo" dojo
-    sudo - dojo -c 'cd /opt/django-DefectDojo/components && bower install'
+    chown -R dojo:dojo /opt/django-DefectDojo
+    su - dojo -c 'cd /opt/django-DefectDojo/components && bower install'
 else
     cd components && bower install && cd ..
 fi


### PR DESCRIPTION
Found while using the new setup.bash to build a new docker image.  The final bower command failed due to permissions issues.  This fixes that bug.