### PR TITLE
adding "cd .." to fix collectstatic

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -287,7 +287,7 @@ fi
 if [ $(id -u) = 0 ]; then
     adduser --disabled-password --gecos "DefectDojo" dojo
     chown -R dojo:dojo /opt/django-DefectDojo
-    su - dojo -c 'cd /opt/django-DefectDojo/components && bower install'
+    su - dojo -c 'cd /opt/django-DefectDojo/components && bower install && cd ..'
 else
     cd components && bower install && cd ..
 fi


### PR DESCRIPTION
Adding a `cd ..` to the setup.bash script after running `bower install` and before running `collectstatic`