### PR TITLE
Updated/fixed Dockerfile and temporarily disabled Zap tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
   - docker build -t $REPO:${TRAVIS_COMMIT::8} .
     # - docker run -e DOJO_ADMIN_USER=$DOJO_ADMIN_USER -e DOJO_ADMIN_PASSWORD=$DOJO_ADMIN_PASSWORD --name dojo -d -p 127.0.0.1:8000:8000 $REPO:${TRAVIS_COMMIT::8} bash /django-DefectDojo/docker/docker-startup.bash
-  - docker run -d -p 8000:8000 --name=$CONTAINER_NAME $REPO:${TRAVIS_COMMIT::8}
+  - docker run -d -p 127.0.0.1:8000:8000 --name=$CONTAINER_NAME $REPO:${TRAVIS_COMMIT::8}
     # - sleep 30 #allow dojo time to startup
   - sudo service docker restart
   - docker logs $CONTAINER_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ before_install:
     # - sleep 30 #allow dojo time to startup
   - sudo service docker restart
   - docker logs $CONTAINER_NAME
-  - docker run -d --name zap --link $CONTAINER_NAME -p 127.0.0.1:8080:8080 -i owasp/zap2docker-stable zap.sh -daemon -host 0.0.0.0 -port 8080 -config api.disablekey=true
+  ## Turn off Zap tests while re-configuring how they run
+  ##- docker run -d --name zap --link $CONTAINER_NAME -p 127.0.0.1:8080:8080 -i owasp/zap2docker-stable zap.sh -daemon -host 0.0.0.0 -port 8080 -config api.disablekey=true
   - docker ps -a
   - docker logs $CONTAINER_NAME
   - echo "Checking to see if dojo is running"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - docker ps -a
   - docker logs $CONTAINER_NAME
   - echo "Checking to see if dojo is running"
-  - curl http:/locahost:8000/login?next=/
+  - curl http://locahost:8000/login?next=/
   ## Selenium and ZAP requirements
   - pip install selenium==2.53.6
   - pip install requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,15 @@ before_install:
     # - docker run -e DOJO_ADMIN_USER=$DOJO_ADMIN_USER -e DOJO_ADMIN_PASSWORD=$DOJO_ADMIN_PASSWORD --name dojo -d -p 127.0.0.1:8000:8000 $REPO:${TRAVIS_COMMIT::8} bash /django-DefectDojo/docker/docker-startup.bash
   - docker run -d -p 127.0.0.1:8000:8000 --name=$CONTAINER_NAME $REPO:${TRAVIS_COMMIT::8}
     # - sleep 30 #allow dojo time to startup
-  - sudo service docker restart
+  ## Why are we restarting docker when it will cause the dojo container to exit aka not be running??
+  ##- sudo service docker restart
   - docker logs $CONTAINER_NAME
   ## Turn off Zap tests while re-configuring how they run
   ##- docker run -d --name zap --link $CONTAINER_NAME -p 127.0.0.1:8080:8080 -i owasp/zap2docker-stable zap.sh -daemon -host 0.0.0.0 -port 8080 -config api.disablekey=true
   - docker ps -a
   - docker logs $CONTAINER_NAME
   - echo "Checking to see if dojo is running"
-  - curl http:/127.0.0.1:8000/login?next=/
+  - curl http:/locahost:8000/login?next=/
   ## Selenium and ZAP requirements
   - pip install selenium==2.53.6
   - pip install requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - docker ps -a
   - docker logs $CONTAINER_NAME
   - echo "Checking to see if dojo is running"
-  - curl http://localhost:8000/login?next=/
+  - curl http:/127.0.0.1:8000/login?next=/
   ## Selenium and ZAP requirements
   - pip install selenium==2.53.6
   - pip install requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - docker ps -a
   - docker logs $CONTAINER_NAME
   - echo "Checking to see if dojo is running"
-  - curl http://locahost:8000/login?next=/
+  - curl http://127.0.0.1:8000/login?next=/
   ## Selenium and ZAP requirements
   - pip install selenium==2.53.6
   - pip install requests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
-
 FROM ubuntu:16.04
-MAINTAINER Matt Tesauro matt.tesauro@owasp.org
+MAINTAINER Matt Tesauro <matt.tesauro@owasp.org>
 
 # Create a single Docker running DefectDojo and all dependencies
 
 RUN apt update \
-    && DEBIAN_FRONTEND=noninteractive apt install -y mysql-server sudo git expect \
+    && DEBIAN_FRONTEND=noninteractive apt install -y mysql-server sudo git expect wget \
     && usermod -d /var/lib/mysql/ mysql \
     && service mysql start \
     && cd /opt \
-    && git clone https://github.com/OWASP/django-DefectDojo.git \
+    && git clone https://github.com/mtesauro/django-DefectDojo.git \
     && export AUTO_DOCKER=yes \
     && /opt/django-DefectDojo/setup.bash \
-    && service mysql stop
+    && cd /tmp \
+    && wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
+    && tar xvfJ wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
+    && sudo chown root:root wkhtmltox/bin/wkhtmltopdf \
+    && sudo cp wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf \
+    && service mysql stop 
 
 WORKDIR /opt/django-DefectDojo
 
-CMD chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+ENTRYPOINT chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
     && service mysql start \
-    && python manage.py runserver 0.0.0.0:8000
+    && su - dojo -c "cd /opt/django-DefectDojo && celery -A dojo worker -l info --concurrency 3 >> /opt/django-DefectDojo/worker.log 2>&1 &" \
+    && su - dojo -c "cd /opt/django-DefectDojo && celery beat -A dojo -l info  >> /opt/django-DefectDojo/beat.log 2>&1 &" \
+    && su - dojo -c "cd /opt/django-DefectDojo && python manage.py runserver 0.0.0.0:8000 >> /opt/django-DefectDojo/dojo.log 2>&1"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update \
     && usermod -d /var/lib/mysql/ mysql \
     && service mysql start \
     && cd /opt \
-    && git clone https://github.com/mtesauro/django-DefectDojo.git \
+    && git clone https://github.com/OWASP/django-DefectDojo.git \
     && export AUTO_DOCKER=yes \
     && /opt/django-DefectDojo/setup.bash \
     && cd /tmp \


### PR DESCRIPTION
Docker file now works for reporting as it starts both celery processes needed by Dojo. You can launch the docker like:

$ docker run -d -p 8000:8000 --name=dojo mtesauro/defect-dojo:1.1

And then go to http://localhost:8000 in a browser. Default login is admin / admin

Note that you have to have -p 127.0.0.1:8000:8000 to keep Travis CI happy.