### PR TITLE
Fix Cover Page PDF Rendering Above TOC on Custom Reports

### DIFF
--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -40,7 +40,7 @@ def add_alerts(self, runinterval):
         target_end__lt=now,
         status='In Progress').order_by('-target_end')
     for eng in stale_engagements:
-        create_notification(event='stale_engagement', 
+        create_notification(event='stale_engagement',
                            title='Stale Engagement: %s' % eng.name,
                            description='The engagement "%s" is stale. Target end was %s.' % (eng.name, eng.target_end.strftime("%b. %d, %Y")),
                            url=reverse('view_engagement', args=(eng.id,)),
@@ -141,8 +141,12 @@ def async_custom_pdf_report(self,
             toc = {'toc-header-text': toc_settings.title,
                    'xsl-style-sheet': temp.name}
 
+        # default the cover to not come first by default
+        cover_first_val=False
+
         cover = None
         if 'cover-page' in selected_widgets:
+            cover_first_val=True
             cp = selected_widgets['cover-page']
             x = urlencode({'title': cp.title,
                            'subtitle': cp.sub_heading,
@@ -156,9 +160,9 @@ def async_custom_pdf_report(self,
         pdf = pdfkit.from_string(bytes,
                                  False,
                                  configuration=config,
-                                 cover=cover,
                                  toc=toc,
-                                 )
+                                 cover=cover,
+                                 cover_first=cover_first_val)
 
         if report.file.name:
             with open(report.file.path, 'w') as f:
@@ -243,4 +247,3 @@ def async_false_history(new_finding, *args, **kwargs):
     if total_findings.count() > 0:
             new_finding.false_p = True
             super(Finding, new_finding).save(*args, **kwargs)
-

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'kombu==3.0.37',
         'sqlalchemy',
         'django-polymorphic==1.2',
-        'pdfkit==0.5.0',
+        'pdfkit==0.6.1',
         'django-overextends',
         'defusedxml',
         'django-tagging',


### PR DESCRIPTION
When creating a **custom** **report** that has a table of contents and its placed at the bottom of the report or anywhere but the top, the generated PDF will always generate the TOC on the first page at the top of the report, rather than respect the order specified in the frag & drop interface. 

This is a missing default with the [pdfkit](https://pypi.python.org/pypi/pdfkit) library where the `cover_first` attribute isn't passed. This PR add this flag, only when you add a cover page widget to your PDF report. Bumping the version of pdfkit to 0.6.1 where the `cover_first` attribute is recognized.

This doesn't seem to affect Product/Engagement reports as the report filter doesn't provide you with the option to provide a cover page.
