### PR TITLE
Updating __init__.py metadata

### DIFF
--- a/dojo/__init__.py
+++ b/dojo/__init__.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app  # noqa
 
-__version__ = '1.1.4'
-__url__ = 'https://github.com/rackerlabs/django-DefectDojo'
-__docs__ = 'http://defectdojo.readthedocs.io/'
-__demo__ = 'http://defectdojo.pythonanywhere.com/'
+__version__ = '1.2.0'
+__url__ = 'https://github.com/OWASP/django-DefectDojo'
+__docs__ = 'https://defectdojo.readthedocs.io/'
+__demo__ = 'https://defectdojo.pythonanywhere.com/'


### PR DESCRIPTION
Updating `dojo/__init__.py` to reflect the latest version (1.2.0), point to the current git repository location, and use https for links.