### PR TITLE
Fixing broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ that should give you an idea of how to use DefectDojo for your own team.
 
 [Engagement Surveys](https://github.com/grendel513/defectDojo-engagement-survey) - A plugin that adds answerable surveys to engagements.
 
-[LDAP Integration](https://pythonhosted.org/django-auth-ldap/)
+[LDAP Integration](https://django-auth-ldap.readthedocs.io/en/latest/)
 
 [SAML Integration](https://pypi.python.org/pypi/djangosaml2/)
 


### PR DESCRIPTION
The "LDAP integration" link is currently broken. It appears
django-auth-ldap has moved their documentation to this URL:
https://django-auth-ldap.readthedocs.io/en/latest/