### PR TITLE
run_dojo.sh: run 'python manage.py runserver' in background

### DIFF
--- a/run_dojo.bash
+++ b/run_dojo.bash
@@ -15,7 +15,7 @@ cpid=$!
 celery beat -A dojo -l info &
 bpid=$!
 
-python manage.py runserver
+python manage.py runserver &
 ppid=$!
 
 tail -f /dev/null


### PR DESCRIPTION
Hi all,

this is just a minor (and very small) fix for "run_dojo.sh". The way the shell script is written implies to run 'python manage.py runserver' in the background. If it should stay in the forground, lines 19-21 would be obsolete (https://github.com/OWASP/django-DefectDojo/blob/master/run_dojo.bash#L19-L21).

Thanks in advance,
Tilmann H.

----

When submitting a pull request, please make sure you have completed the following checklist:

- [N/A] Your code is pep8 compliant (Dojo's code isn't currently pep8 compliant, but we're trying to correct that)
- [N/A] If this is a new feature and not a bug fix, you've included the proper docuemntation under the /docs folder
