### PR TITLE
Add IP for hash in openvas parser.

### DIFF
--- a/dojo/tools/openvas_csv/parser.py
+++ b/dojo/tools/openvas_csv/parser.py
@@ -328,7 +328,7 @@ class OpenVASUploadCsvParser(object):
                 column_number += 1
 
             if finding is not None:
-                key = hashlib.md5(finding.severity + '|' + finding.title + '|' + finding.description).hexdigest()
+                key = hashlib.md5(finding.url + '|' + finding.severity + '|' + finding.title + '|' + finding.description).hexdigest()
 
                 if key not in self.dupes:
                     self.dupes[key] = finding


### PR DESCRIPTION
If OpenVas found same vulnerability on different hosts, Dojo will ignore duplicates. Sample [csv](https://github.com/OWASP/django-DefectDojo/files/1555460/report.txt) in attached file.