### PR TITLE
added missing import of add_issue_task

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -23,7 +23,7 @@ from dojo.models import Product_Type, Finding, Product, Engagement, ScanSettings
     Tool_Product_Settings, Cred_User, Cred_Mapping, Test_Type
 from dojo.utils import get_page_items, add_breadcrumb, get_punchcard_data, get_system_setting, create_notification
 from custom_field.models import CustomFieldValue, CustomField
-from  dojo.tasks import add_epic_task
+from dojo.tasks import add_epic_task, add_issue_task
 from tagging.models import Tag
 from tagging.utils import get_tag_list
 from tagging.views import TaggedItem


### PR DESCRIPTION
I've encountered this exception while adding (with a POST request) an ad-hoc finding to a product and pushing it to JIRA:

```
Exception Type: NameError at /product/2/ad_hoc_finding
Exception Value: global name 'add_issue_task' is not defined
```

I think it is only a missing import of "add_issue_task" from "dojo.tasks".

----
When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is pep8 compliant (Dojo's code isn't currently pep8 compliant, but we're trying to correct that)
- [ ] If this is a new feature and not a bug fix, you've included the proper docuemntation under the /docs folder
